### PR TITLE
ci: dynamically enforce branch protection against lock upgrades

### DIFF
--- a/justfile
+++ b/justfile
@@ -54,10 +54,26 @@ clean:
 
 # Upgrade uv.lock and sync
 lock-upgrade:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    BRANCH=$(git rev-parse --abbrev-ref HEAD)
+    if [ "$BRANCH" = "main" ]; then
+        TIMESTAMP=$(date +%s)
+        NEW_BRANCH="chore/update-deps-$TIMESTAMP"
+        echo "Creating new branch $NEW_BRANCH to protect main..."
+        git checkout -b "$NEW_BRANCH"
+    fi
+
     uv lock --upgrade
     uv sync
     git add pyproject.toml uv.lock
     git commit -m "chore: update dependencies" || true
+
+    if [ "$BRANCH" = "main" ]; then
+        echo "Pushing new dependency branch upstream..."
+        git push -u origin "$NEW_BRANCH"
+    fi
 
 # Bump project version (usage: just bump-version <major|minor|patch|dev|beta|alpha|rc>)
 bump-version part:


### PR DESCRIPTION
Refactors the `lock-upgrade` recipe utilizing a bash execution block to detect if the user's active Git branch is `main`. If so, it organically generates a new timestamped utility branch (e.g., `chore/update-deps-<ts>`), checks it out prior to running `uv lock --upgrade`, commits the `pyproject.toml` and lockfile bumps, and selectively pushes that new branch to `origin` instead of dirtying `main`.