### PR TITLE
fix: gracefully exit lock-upgrade without creating a branch/pr if no updates

### DIFF
--- a/justfile
+++ b/justfile
@@ -67,8 +67,18 @@ lock-upgrade:
 
     uv lock --upgrade
     uv sync
+
+    if git diff --quiet pyproject.toml uv.lock; then
+        echo "No dependencies to update."
+        if [ "$BRANCH" = "main" ]; then
+            git checkout main
+            git branch -D "$NEW_BRANCH"
+        fi
+        exit 0
+    fi
+
     git add pyproject.toml uv.lock
-    git commit -m "chore: update dependencies" || true
+    git commit -m "chore: update dependencies"
 
     if [ "$BRANCH" = "main" ]; then
         echo "Pushing new dependency branch upstream..."


### PR DESCRIPTION
When no uv.lock changes are found, we now exit early to prevent failing gh pr creations due to empty commits.