### PR TITLE
fix: resolve duplicate auth header in bump-version workflow

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -19,6 +19,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   bump:
@@ -27,6 +28,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7


### PR DESCRIPTION
## Problem

The Bump Version workflow fails with:

```
remote: Duplicate header: "Authorization"
fatal: unable to access 'https://github.com/jkomalley/odot/': The requested URL returned error: 400
```

## Root Cause

`actions/checkout` persists its HTTPS auth token in the local git config. When `peter-evans/create-pull-request` then configures its own credentials, the two Authorization headers conflict, causing a 400 error.

## Fix

1. **`persist-credentials: false`** on the `actions/checkout` step — prevents it from leaving its token in the git config, so `create-pull-request` can set its own cleanly.
2. **`pull-requests: write`** permission — required by `create-pull-request` to open PRs via the GitHub API.