### PR TITLE
fix: rename --pending to --todo to resolve -p flag collision

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ odot list
 You can optionally filter the list by status:
 
 ```bash
-odot list --done      # Show only completed tasks
-odot list --pending   # Show only open tasks
+odot list --done   # Show only completed tasks
+odot list --todo   # Show only open tasks
 ```
 
 ### Showing a Task

--- a/src/odot/cli.py
+++ b/src/odot/cli.py
@@ -126,7 +126,7 @@ def show(
 def list_tasks(
     ctx: typer.Context,
     done: Annotated[
-        bool | None, typer.Option("-d/-p", "--done/--pending", help="Filter by status")
+        bool | None, typer.Option("-d/-t", "--done/--todo", help="Filter by status")
     ] = None,
 ):
     """List tasks, optionally filtered by status."""
@@ -168,7 +168,7 @@ def update(
     ] = None,
     done: Annotated[
         bool | None,
-        typer.Option("-d/-p", "--done/--pending", help="Update completion status"),
+        typer.Option("-d/-t", "--done/--todo", help="Update completion status"),
     ] = None,
 ):
     """Update properties of an existing task."""


### PR DESCRIPTION
## Summary

Renames `--done/--pending` (`-d/-p`) to `--done/--todo` (`-d/-t`) in both the `list` and `update` commands to resolve the `-p` short flag collision with `--priority`.

## Changes

- **`cli.py`**: Updated flag declarations in `list_tasks` and `update` commands from `-d/-p` / `--done/--pending` to `-d/-t` / `--done/--todo`.
- **`README.md`**: Updated usage examples to reflect `--todo` instead of `--pending`.

## Verification

- All 28 tests pass with 100% coverage.
- Pre-commit hooks (ruff, ruff-format, ty) all pass.

Closes #22
Closes #26