### PR TITLE
fix: replace unclosed session generator with explicit ctx.call_on_close lifecycle

### DIFF
--- a/src/odot/cli.py
+++ b/src/odot/cli.py
@@ -69,7 +69,9 @@ def main_callback(
     """A minimalist CLI task manager."""
     # Ensure ctx.obj is initialized
     if getattr(ctx, "obj", None) is None:
-        ctx.obj = next(database.get_session())
+        session = Session(database.engine)
+        ctx.obj = session
+        ctx.call_on_close(session.close)
 
 
 @app.command()

--- a/src/odot/database.py
+++ b/src/odot/database.py
@@ -2,7 +2,7 @@
 
 import os
 from pathlib import Path
-from sqlmodel import Session, SQLModel, create_engine
+from sqlmodel import SQLModel, create_engine
 
 # Evaluate ODOT_DB_PATH for configuration overrides, falling back to a local default
 _db_env = os.environ.get("ODOT_DB_PATH")
@@ -28,9 +28,3 @@ def create_db_and_tables() -> None:
     from odot.models import Task  # noqa: F401
 
     SQLModel.metadata.create_all(engine)
-
-
-def get_session():
-    """Dependency provider for database sessions."""
-    with Session(engine) as session:
-        yield session

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,13 +9,12 @@ runner = CliRunner()
 
 @pytest.fixture(autouse=True)
 def override_db_dependency(monkeypatch, session):
-    """Override the database session for all CLI tests via monkeypatching the context provider."""
-    from odot import database
+    """Override the database session for all CLI tests via monkeypatching Session."""
 
-    def mock_get_session():
-        yield session
+    def mock_session(*args, **kwargs):
+        return session
 
-    monkeypatch.setattr(database, "get_session", mock_get_session)
+    monkeypatch.setattr("odot.cli.Session", mock_session)
 
 
 def test_init_db():

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -82,16 +82,3 @@ def test_database_directory_env_override(tmp_path, monkeypatch):
 
     assert target_dir.exists()
     assert database.DB_FILE == target_file
-
-
-def test_get_session():
-    """Test the session generator yields successfully."""
-    gen = database.get_session()
-    session = next(gen)
-    assert session is not None
-
-    # Assert generator handles exit smoothly
-    try:
-        next(gen)
-    except StopIteration:
-        pass


### PR DESCRIPTION
## Summary

Fixes a database connection leak in the Typer CLI where the `get_session` generator yielded a context manager that was never properly closed. 

## Changes

- Removed the unused `get_session()` generator pattern from `database.py`.
- Integrated `ctx.call_on_close(session.close)` directly into the `main_callback` in `cli.py`, which is the correct idiomatic way to manage connection lifecycles in Typer.
- Updated the tests in `test_cli.py` and `test_database.py` to match the new architecture.

## Verification

- Wrote a custom SQLAlchemy session hook script during development to empirically verify the session was leaking in `main`, and that the `with_resource` fix failed to close it. Confirmed that `ctx.call_on_close` successfully tore down the connection.
- All 27 tests pass with 100% test coverage.

Closes #21