### PR TITLE
feat: clear all tasks regardless of status

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,15 @@ odot rm 1
 odot rm 1 --force
 ```
 
+### Purging All Tasks
+
+Delete all tasks from the database entirely, resetting your task list. Because this is a destructive action, `odot` will display a warning and ask for explicit confirmation unless you use the `--force` flag.
+
+```bash
+odot purge          # Prompts for confirmation with a warning
+odot purge --force  # Skip confirmation
+```
+
 ## Development
 
 If you wish to contribute or modify `odot` locally, ensure you have `uv` (for Python dependency management), `gh` (the GitHub CLI, for workflow automation), and `just` (the recipe task runner) installed.

--- a/src/odot/cli.py
+++ b/src/odot/cli.py
@@ -278,6 +278,28 @@ def rm(
         raise typer.Exit(code=1)
 
 
+@app.command()
+def purge(
+    ctx: typer.Context,
+    force: Annotated[
+        bool, typer.Option("-f", "--force", help="Force deletion without confirmation")
+    ] = False,
+):
+    """Delete all tasks, completely resetting the database."""
+    db = ctx.obj
+
+    if not force:
+        console.print(
+            "[bold red]WARNING: This will permanently delete ALL tasks.[/bold red]"
+        )
+        typer.confirm(
+            "Are you incredibly sure you want to purge all records?", abort=True
+        )
+
+    count = core.delete_all_tasks(db=db)
+    console.print(f"[green]Purged {count} tasks from the database.[/green]")
+
+
 @app.command(name="init-db")
 def init_db():
     """Initialize the database."""

--- a/src/odot/core.py
+++ b/src/odot/core.py
@@ -116,3 +116,20 @@ def delete_task(db: Session, task_id: int) -> bool:
     db.delete(db_task)
     db.commit()
     return True
+
+
+def delete_all_tasks(db: Session) -> int:
+    """Delete all tasks from the database.
+
+    Args:
+        db: SQLModel Session instance.
+
+    Returns:
+        The total number of deleted Task records.
+    """
+    from sqlmodel import delete
+
+    statement = delete(Task)
+    result = db.exec(statement)
+    db.commit()
+    return result.rowcount

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -264,6 +264,31 @@ def test_rm_command(monkeypatch):
     assert "Task 999 not found" in missing.stdout
 
 
+def test_purge_command():
+    """Test purging all tasks via CLI."""
+    runner.invoke(app, ["add", "Delete me 1"])
+    runner.invoke(app, ["add", "Delete me 2"])
+
+    # Check that it aborts without --force or "y"
+    aborted = runner.invoke(app, ["purge"], input="n\n")
+    assert aborted.exit_code == 1
+    assert "WARNING: This will permanently delete ALL tasks." in aborted.stdout
+
+    # Verify tasks are still there
+    list_after_abort = runner.invoke(app, ["list"])
+    assert "Delete me 1" in list_after_abort.stdout
+
+    # Check mapping prompt affirmatively natively
+    confirmed = runner.invoke(app, ["purge"], input="y\n")
+    assert confirmed.exit_code == 0
+    assert "Purged 2 tasks" in confirmed.stdout
+
+    # Now with 0 tasks and --force
+    force = runner.invoke(app, ["purge", "--force"])
+    assert force.exit_code == 0
+    assert "Purged 0 tasks" in force.stdout
+
+
 def test_main_execution(monkeypatch):
     """Test the main entrypoint function directly."""
     called = False

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -137,3 +137,21 @@ def test_search_tasks(session):
     # Match none
     results = core.search_tasks(db=session, phrase="notfound")
     assert len(results) == 0
+
+
+def test_delete_all_tasks(session):
+    """Test dropping all records entirely regardless of status."""
+    core.add_task(db=session, task_data=TaskCreate(content="Dummy task 1"))
+    core.add_task(db=session, task_data=TaskCreate(content="Dummy task 2"))
+    core.add_task(db=session, task_data=TaskCreate(content="Dummy task 3"))
+
+    assert len(core.list_tasks(db=session)) == 3
+
+    count = core.delete_all_tasks(db=session)
+    assert count == 3
+
+    assert len(core.list_tasks(db=session)) == 0
+
+    # Ensure empty DB drops 0 safely
+    count_again = core.delete_all_tasks(db=session)
+    assert count_again == 0


### PR DESCRIPTION
Closes #20\n\nAdds a `purge` command that deleting all tasks from the database regardless of their status.