### PR TITLE
feat: delete all completed tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,15 @@ odot rm 1
 odot rm 1 --force
 ```
 
+### Cleaning Completed Tasks
+
+Delete all tasks currently marked as 'Done' from the database in bulk. Because this drops data, `odot` prompts for confirmation unless you use the `--force` flag.
+
+```bash
+odot clean          # Prompts for confirmation
+odot clean --force  # Skip confirmation
+```
+
 ### Purging All Tasks
 
 Delete all tasks from the database entirely, resetting your task list. Because this is a destructive action, `odot` will display a warning and ask for explicit confirmation unless you use the `--force` flag.

--- a/src/odot/cli.py
+++ b/src/odot/cli.py
@@ -279,6 +279,28 @@ def rm(
 
 
 @app.command()
+def clean(
+    ctx: typer.Context,
+    force: Annotated[
+        bool, typer.Option("-f", "--force", help="Force deletion without confirmation")
+    ] = False,
+):
+    """Delete all completed tasks from the database."""
+    db = ctx.obj
+
+    if not force:
+        typer.confirm(
+            "Are you sure you want to delete all completed tasks?", abort=True
+        )
+
+    count = core.delete_completed_tasks(db=db)
+    if count == 0:
+        console.print("[yellow]No completed tasks to delete.[/yellow]")
+    else:
+        console.print(f"[green]Deleted {count} completed tasks.[/green]")
+
+
+@app.command()
 def purge(
     ctx: typer.Context,
     force: Annotated[

--- a/src/odot/core.py
+++ b/src/odot/core.py
@@ -50,9 +50,9 @@ def list_tasks(
     """
     statement = select(Task)
     if is_done is not None:
-        statement = statement.where(Task.is_done == is_done)
+        statement = statement.where(col(Task.is_done) == is_done)
     if category is not None:
-        statement = statement.where(Task.category == category)
+        statement = statement.where(col(Task.category) == category)
     return list(db.exec(statement).all())
 
 
@@ -116,6 +116,23 @@ def delete_task(db: Session, task_id: int) -> bool:
     db.delete(db_task)
     db.commit()
     return True
+
+
+def delete_completed_tasks(db: Session) -> int:
+    """Delete all tasks marked as done from the database.
+
+    Args:
+        db: SQLModel Session instance.
+
+    Returns:
+        The total number of deleted Task records.
+    """
+    from sqlmodel import delete
+
+    statement = delete(Task).where(col(Task.is_done))
+    result = db.exec(statement)
+    db.commit()
+    return result.rowcount
 
 
 def delete_all_tasks(db: Session) -> int:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -264,6 +264,38 @@ def test_rm_command(monkeypatch):
     assert "Task 999 not found" in missing.stdout
 
 
+def test_clean_command():
+    """Test cleaning completed tasks via CLI."""
+    runner.invoke(app, ["add", "Keep me 1"])
+    runner.invoke(app, ["add", "Delete me 1"])
+    runner.invoke(app, ["add", "Keep me 2"])
+    runner.invoke(app, ["add", "Delete me 2"])
+
+    runner.invoke(app, ["update", "2", "--done"])
+    runner.invoke(app, ["update", "4", "--done"])
+
+    # Base abort interaction
+    aborted = runner.invoke(app, ["clean"], input="n\n")
+    assert aborted.exit_code == 1
+    assert "Are you sure you want to delete all completed tasks?" in aborted.stdout
+
+    # Actually execute cleanly via prompt
+    confirmed = runner.invoke(app, ["clean"], input="y\n")
+    assert confirmed.exit_code == 0
+    assert "Deleted 2 completed tasks." in confirmed.stdout
+
+    # List mapping validation ensuring properties weren't wiped entirely globally
+    list_after = runner.invoke(app, ["list"])
+    assert "Keep me 1" in list_after.stdout
+    assert "Keep me 2" in list_after.stdout
+    assert "Delete me 1" not in list_after.stdout
+
+    # Now verify mapping gracefully returns yellow context missing records safely
+    empty = runner.invoke(app, ["clean", "--force"])
+    assert empty.exit_code == 0
+    assert "No completed tasks to delete." in empty.stdout
+
+
 def test_purge_command():
     """Test purging all tasks via CLI."""
     runner.invoke(app, ["add", "Delete me 1"])

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -139,6 +139,34 @@ def test_search_tasks(session):
     assert len(results) == 0
 
 
+def test_delete_completed_tasks(session):
+    """Test dropping only records marked as done."""
+    t1 = core.add_task(db=session, task_data=TaskCreate(content="Dummy task 1"))
+    t2 = core.add_task(db=session, task_data=TaskCreate(content="Dummy task 2"))
+    t3 = core.add_task(db=session, task_data=TaskCreate(content="Dummy task 3"))
+
+    assert t1.id is not None
+    assert t3.id is not None
+
+    # Mark task 1 and 3 as done
+    core.update_task(db=session, task_id=t1.id, data=TaskUpdate(is_done=True))
+    core.update_task(db=session, task_id=t3.id, data=TaskUpdate(is_done=True))
+
+    assert len(core.list_tasks(db=session)) == 3
+
+    count = core.delete_completed_tasks(db=session)
+    assert count == 2
+
+    # Verify only task 2 remains
+    remaining = core.list_tasks(db=session)
+    assert len(remaining) == 1
+    assert remaining[0].id == t2.id
+
+    # Verify repeated calls return 0
+    count_again = core.delete_completed_tasks(db=session)
+    assert count_again == 0
+
+
 def test_delete_all_tasks(session):
     """Test dropping all records entirely regardless of status."""
     core.add_task(db=session, task_data=TaskCreate(content="Dummy task 1"))


### PR DESCRIPTION
Closes #19 

Adds a `clean` command that deletes all tasks successfully completed from the database.