### PR TITLE
feat: add `updated_at` timestamp to Task model

### DIFF
--- a/src/odot/cli.py
+++ b/src/odot/cli.py
@@ -122,6 +122,10 @@ def show(
     local_time = task.created_at.astimezone()
     table.add_row("Created At", local_time.strftime(DATETIME_FORMAT))
 
+    if task.updated_at:
+        local_updated = task.updated_at.astimezone()
+        table.add_row("Updated At", local_updated.strftime(DATETIME_FORMAT))
+
     console.print(table)
 
 

--- a/src/odot/core.py
+++ b/src/odot/core.py
@@ -113,6 +113,9 @@ def update_task(db: Session, task_id: int, data: TaskUpdate) -> Task | None:
         return db_task
 
     db_task.sqlmodel_update(update_data)
+    from datetime import datetime, timezone
+
+    db_task.updated_at = datetime.now(timezone.utc)
 
     db.add(db_task)
     db.commit()

--- a/src/odot/models.py
+++ b/src/odot/models.py
@@ -41,3 +41,4 @@ class Task(TaskBase, table=True):
     created_at: datetime = Field(
         default_factory=lambda: datetime.now(timezone.utc), nullable=False
     )
+    updated_at: datetime | None = Field(default=None)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -95,6 +95,12 @@ def test_show_command(monkeypatch):
     assert result.exit_code == 0
     assert "Show me" in result.stdout
     assert "Pending" in result.stdout
+    assert "Updated At" not in result.stdout
+
+    runner.invoke(app, ["update", "1", "-p", "3"])
+    updated_result = runner.invoke(app, ["show", "1"])
+    assert updated_result.exit_code == 0
+    assert "Updated At" in updated_result.stdout
 
     # Test missing task
     missing = runner.invoke(app, ["show", "999"])

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -132,6 +132,8 @@ def test_update_task(session):
         updated.content == "Old Task"
     )  # Stays evaluating explicitly old contents cleanly
     assert updated.priority == 3
+    assert updated.updated_at is not None
+    assert updated.updated_at > updated.created_at
 
     # Check targeting a missing ID evaluation tracking safely
     missing = core.update_task(

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -45,6 +45,7 @@ def test_task_table_defaults():
     assert task.id is None
     assert task.is_done is False
     assert task.created_at is not None
+    assert task.updated_at is None
 
 
 def test_task_update_optional_fields():


### PR DESCRIPTION
Resolves #23.

Adds an `updated_at` timestamp to the `Task` model to track when tasks are modified.

### Features
- Added `updated_at` to `Task` model (defaults to `None`).
- `core.update_task()` now sets `updated_at` upon any successful modification.
- `odot show` renders the `Updated At` timestamp in the local timezone.
- Added tests for , , and  to ensure functionality and maintain 100% coverage.

**Note**: Since project is in v0.1.0, this schema change will require users to recreate their databases. No Alembic migration script is included per current conventions, but is documented here.