### PR TITLE
fix: escape user content in HTML report to prevent XSS

### DIFF
--- a/src/odot/core.py
+++ b/src/odot/core.py
@@ -301,6 +301,7 @@ def generate_html_report(tasks: list[Task]) -> str:
         An HTML formatted string representing the tasks.
     """
     from datetime import datetime
+    from html import escape
     from itertools import groupby
 
     css = """
@@ -338,14 +339,16 @@ def generate_html_report(tasks: list[Task]) -> str:
     else:
         sorted_tasks = sorted(tasks, key=lambda t: t.category)
         for category, category_tasks in groupby(sorted_tasks, key=lambda t: t.category):
-            html.append(f"    <h2>{category.title()}</h2>")
+            html.append(f"    <h2>{escape(category.title())}</h2>")
             html.append("    <ul class='task-list'>")
             for task in category_tasks:
                 status_class = "done" if task.is_done else "pending"
                 checkbox = "✓" if task.is_done else "○"
                 html.append(f"        <li class='task-item {status_class}'>")
                 html.append(f"            <span class='checkbox'>{checkbox}</span>")
-                html.append(f"            <span class='content'>{task.content}</span>")
+                html.append(
+                    f"            <span class='content'>{escape(task.content)}</span>"
+                )
                 html.append(
                     f"            <span class='priority'>Priority: {task.priority}</span>"
                 )

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -357,3 +357,22 @@ def test_generate_html_report():
 
     empty_report = core.generate_html_report([])
     assert "<p>No tasks found.</p>" in empty_report
+
+
+def test_generate_html_report_escapes_user_content():
+    """HTML special characters in user content must be escaped."""
+    tasks = [
+        Task(
+            content='Review <head> section & fix "quotes"',
+            priority=1,
+            category="<script>alert('xss')</script>",
+            is_done=False,
+        )
+    ]
+    report = core.generate_html_report(tasks)
+
+    assert "<script>" not in report
+    assert "&lt;head&gt;" in report
+    assert "&amp;" in report
+    assert "&quot;quotes&quot;" in report
+    assert "&lt;Script&gt;" in report


### PR DESCRIPTION
## Summary

- Imports `html.escape` inside `generate_html_report()` and wraps all user-provided content (`task.content` and `category`) before interpolating into HTML
- Prevents XSS if a task contains `<script>` or other HTML, and also fixes layout-breaking characters like `<`, `>`, `&`, `"`

## Test plan

- [x] Added `test_generate_html_report_escapes_user_content` — creates a task with HTML special characters in both content and category, asserts they are escaped in the output and that no raw `<script>` tag appears
- [x] All 41 existing tests pass

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)