### PR TITLE
fix: assert updated_at unchanged on no-op update_task

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -145,6 +145,7 @@ def test_update_task(session):
     updated_noop = core.update_task(db=session, task_id=task.id, data=TaskUpdate())
     assert updated_noop is not None
     assert updated_noop.content == "Old Task"
+    assert updated_noop.updated_at == updated.updated_at
 
 
 def test_delete_task(session):


### PR DESCRIPTION
## Summary

- Adds an assertion to `test_update_task` verifying that `updated_at` is not stamped when `update_task()` is called with no fields set (the no-op path already short-circuits correctly in `core.py` — this closes the test gap)

## Test plan

- [x] `test_update_task` now asserts `updated_noop.updated_at == updated.updated_at`
- [x] All 41 tests pass

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)