### PR TITLE
feat: auto-initialize database on first use

### DIFF
--- a/src/odot/cli.py
+++ b/src/odot/cli.py
@@ -68,8 +68,11 @@ def main_callback(
     ] = None,
 ):
     """A minimalist CLI task manager."""
-    # Ensure ctx.obj is initialized
     if getattr(ctx, "obj", None) is None:
+        db_path = database.get_db_path()
+        if not db_path.exists():
+            database.create_db_and_tables()
+            console.print(f"[dim]Database initialized at {db_path}[/dim]")
         session = Session(database.get_engine())
         ctx.obj = session
         ctx.call_on_close(session.close)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,13 +8,18 @@ runner = CliRunner()
 
 
 @pytest.fixture(autouse=True)
-def override_db_dependency(monkeypatch, session):
+def override_db_dependency(monkeypatch, session, tmp_path):
     """Override the database session for all CLI tests via monkeypatching Session."""
 
     def mock_session(*args, **kwargs):
         return session
 
     monkeypatch.setattr("odot.cli.Session", mock_session)
+
+    # Provide a pre-existing db path so auto-init doesn't trigger in unrelated tests
+    fake_db = tmp_path / "db.sqlite"
+    fake_db.touch()
+    monkeypatch.setattr("odot.database.get_db_path", lambda: fake_db)
 
 
 def test_init_db():
@@ -518,3 +523,19 @@ def test_module_execution():
     )
     assert result.returncode == 0
     assert "A minimalist CLI task manager." in result.stdout
+
+
+def test_auto_initializes_database(monkeypatch, tmp_path):
+    """First command auto-inits the DB when the file doesn't exist yet."""
+    non_existent = tmp_path / "new_db.sqlite"
+    monkeypatch.setattr("odot.database.get_db_path", lambda: non_existent)
+
+    initialized = []
+    monkeypatch.setattr(
+        "odot.database.create_db_and_tables", lambda: initialized.append(True)
+    )
+
+    result = runner.invoke(app, ["list"])
+    assert result.exit_code == 0
+    assert initialized, "create_db_and_tables should have been called"
+    assert "Database initialized" in result.stdout


### PR DESCRIPTION
## Summary

- `main_callback` now checks whether the db file exists before opening a session; if it doesn't, it calls `database.create_db_and_tables()` and prints a dim notice (`Database initialized at <path>`)
- `init-db` remains available as an explicit re-initialization command
- The README's "zero configuration" promise now holds: `odot add "task"` works immediately after install

## Test plan

- [x] Added `test_auto_initializes_database` — patches `get_db_path` to return a non-existent path, verifies `create_db_and_tables` is called and the init message appears
- [x] Updated the autouse `override_db_dependency` fixture to patch `get_db_path` with a pre-existing temp file so the auto-init path doesn't interfere with unrelated tests
- [x] All 42 tests pass

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)