### PR TITLE
feat: add 'done' and 'undo' shortcut commands

### DIFF
--- a/src/odot/cli.py
+++ b/src/odot/cli.py
@@ -291,6 +291,40 @@ def update(
 
 
 @app.command()
+def done(
+    ctx: typer.Context,
+    task_id: Annotated[
+        int | None, typer.Argument(help="Task ID to mark as done")
+    ] = None,
+):
+    """Mark a task as done."""
+    db = ctx.obj
+    if task_id is None:
+        task_id = prompt_task_selection(db, "mark done")
+    task = core.update_task(db=db, task_id=task_id, data=TaskUpdate(is_done=True))
+    if not task:
+        console.print(f"[red]Task {task_id} not found.[/red]")
+        raise typer.Exit(code=1)
+    console.print(f"[green]Task {task.id} marked as done.[/green]")
+
+
+@app.command()
+def undo(
+    ctx: typer.Context,
+    task_id: Annotated[int | None, typer.Argument(help="Task ID to re-open")] = None,
+):
+    """Re-open a completed task."""
+    db = ctx.obj
+    if task_id is None:
+        task_id = prompt_task_selection(db, "re-open")
+    task = core.update_task(db=db, task_id=task_id, data=TaskUpdate(is_done=False))
+    if not task:
+        console.print(f"[red]Task {task_id} not found.[/red]")
+        raise typer.Exit(code=1)
+    console.print(f"[green]Task {task.id} re-opened.[/green]")
+
+
+@app.command()
 def rm(
     ctx: typer.Context,
     task_id: Annotated[int | None, typer.Argument(help="Task ID to remove")] = None,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -261,6 +261,49 @@ def test_update_command(monkeypatch):
     assert "Task 999 not found" in missing.stdout
 
 
+def test_done_command(monkeypatch):
+    """Test marking a task as done via the done shortcut command."""
+    runner.invoke(app, ["add", "Finish me"])
+
+    result = runner.invoke(app, ["done", "1"])
+    assert result.exit_code == 0
+    assert "marked as done" in result.stdout
+
+    verify = runner.invoke(app, ["show", "1"])
+    assert "Done" in verify.stdout
+
+    missing = runner.invoke(app, ["done", "999"])
+    assert missing.exit_code == 1
+    assert "Task 999 not found" in missing.stdout
+
+    monkeypatch.setattr("odot.cli.prompt_task_selection", lambda db, action: 1)
+    interactive = runner.invoke(app, ["done"])
+    assert interactive.exit_code == 0
+    assert "marked as done" in interactive.stdout
+
+
+def test_undo_command(monkeypatch):
+    """Test re-opening a completed task via the undo shortcut command."""
+    runner.invoke(app, ["add", "Already done"])
+    runner.invoke(app, ["done", "1"])
+
+    result = runner.invoke(app, ["undo", "1"])
+    assert result.exit_code == 0
+    assert "re-opened" in result.stdout
+
+    verify = runner.invoke(app, ["show", "1"])
+    assert "Pending" in verify.stdout
+
+    missing = runner.invoke(app, ["undo", "999"])
+    assert missing.exit_code == 1
+    assert "Task 999 not found" in missing.stdout
+
+    monkeypatch.setattr("odot.cli.prompt_task_selection", lambda db, action: 1)
+    interactive = runner.invoke(app, ["undo"])
+    assert interactive.exit_code == 0
+    assert "re-opened" in interactive.stdout
+
+
 def test_rm_command(monkeypatch):
     """Test removing a task via CLI."""
     runner.invoke(app, ["add", "Delete me"])


### PR DESCRIPTION
## Summary

- Adds `odot done [TASK_ID]` — marks a task as completed; falls back to interactive selection if no ID given
- Adds `odot undo [TASK_ID]` — re-opens a completed task; same interactive fallback
- Both are thin wrappers around the existing `core.update_task` + `TaskUpdate(is_done=...)` path

## Test plan

- [x] `test_done_command` — covers direct ID, missing ID (exit 1), and interactive selection
- [x] `test_undo_command` — covers direct ID, missing ID (exit 1), and interactive selection
- [x] All 44 tests pass

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)