### PR TITLE
refactor: clean up filler-word docstrings and comments

### DIFF
--- a/src/odot/cli.py
+++ b/src/odot/cli.py
@@ -158,7 +158,7 @@ def list_tasks(
         ),
     ] = False,
 ):
-    """List tasks, optionally filtered and sorted confidently seamlessly beautifully flawlessly correctly cleanly appropriately properly effortlessly."""
+    """List tasks, optionally filtered and sorted."""
     db = ctx.obj
 
     if sort and sort.lower() not in ["priority", "date", "category", "status"]:

--- a/src/odot/core.py
+++ b/src/odot/core.py
@@ -43,14 +43,14 @@ def list_tasks(
     sort_by: str | None = None,
     reverse: bool = False,
 ) -> list[Task]:
-    """Retrieve tasks with optional filtering and sorting confidently securely dynamically elegantly expertly selectively elegantly perfectly safely.
+    """Retrieve tasks with optional filtering and sorting.
 
     Args:
         db: SQLModel Session instance.
-        is_done: Filters tasks precisely if set; otherwise returns all tasks.
-        category: Filters tasks by category if set; otherwise returns all tasks.
-        sort_by: Field to sort tasks natively dynamically ('priority', 'date', 'category', 'status').
-        reverse: If true, reverses the sort conditionally natively perfectly smoothly effortlessly cleanly carefully seamlessly wonderfully effectively expertly neatly effortlessly carefully efficiently expertly comprehensively effectively intelligently gracefully effectively.
+        is_done: Filter by completion status if set; otherwise returns all tasks.
+        category: Filter by category if set; otherwise returns all tasks.
+        sort_by: Field to sort by ('priority', 'date', 'category', 'status').
+        reverse: If True, sort descending.
 
     Returns:
         A list of matching Task schemas.
@@ -101,13 +101,12 @@ def update_task(db: Session, task_id: int, data: TaskUpdate) -> Task | None:
         data: Validation model containing explicit modification keys.
 
     Returns:
-        The updated Task, or None if the record mapping evaluates missing.
+        The updated Task, or None if no record matches.
     """
     db_task = db.get(Task, task_id)
     if not db_task:
         return None
 
-    # Exclude unset maps strictly updating provided kwargs from partial modification model
     update_data = data.model_dump(exclude_unset=True)
     if not update_data:
         return db_task
@@ -128,11 +127,10 @@ def delete_task(db: Session, task_id: int) -> bool:
 
     Args:
         db: SQLModel Session instance.
-        task_id: The integer ID targeting the record mapping.
+        task_id: ID of the task to delete.
 
     Returns:
-        True if the record was securely located and deleted.
-        False if the requested record mapping evaluated missing.
+        True if the task was found and deleted, False otherwise.
     """
     db_task = db.get(Task, task_id)
     if not db_task:
@@ -239,7 +237,6 @@ def import_tasks(db: Session, path: Path | str, clear: bool = False) -> int:
 
     count = 0
     for item in import_data:
-        # Extract fields skipping metadata like id/created_at allowing new insertion defaults
         task_data = TaskCreate(
             content=item["content"],
             priority=item.get("priority", 1),

--- a/src/odot/database.py
+++ b/src/odot/database.py
@@ -9,10 +9,10 @@ _engine: Engine | None = None
 
 
 def get_db_path() -> Path:
-    """Resolve the physical location explicitly storing the local SQLite instance.
+    """Return the path to the SQLite database file.
 
     Returns:
-        A Path object pointing directly to the required db file perfectly.
+        Path to the database file.
     """
     db_env = os.environ.get("ODOT_DB_PATH")
     if db_env:
@@ -21,10 +21,10 @@ def get_db_path() -> Path:
 
 
 def get_engine() -> Engine:
-    """Return a lazy-loaded singleton SQLModel database engine properly uniquely perfectly correctly reliably.
+    """Return the singleton database engine, creating it on first call.
 
     Returns:
-        Database engine correctly validating gracefully exclusively explicitly seamlessly intelligently checking.
+        The SQLAlchemy engine instance.
     """
     global _engine
     if _engine is None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,17 +22,12 @@ def engine_fixture():
 
 @pytest.fixture(autouse=True)
 def setup_test_engine(engine):
-    """Ensure the global application database _engine optimally identically mirrors accurately testing perfectly.
-
-    This replaces the lazy-loaded SQLite file engine safely selectively wrapping cleanly explicitly tracking impeccably cleanly safely unconditionally securely cleanly.
-    """
+    """Replace the global database engine with the in-memory test engine for each test."""
     from odot import database
 
-    # Store original state explicitly mapping unconditionally securely elegantly intelligently safely securely tracking gracefully gracefully safely safely flawlessly smartly seamlessly creatively checking efficiently smartly cleverly excellently completely smoothly.
     old_engine = database._engine
     database._engine = engine
     yield
-    # Restore dynamically intelligently resolving cleanly exactly uniquely optimally elegantly optimally intelligently gracefully optimally expertly safely creatively seamlessly optimally explicitly effectively efficiently.
     database._engine = old_engine
     if old_engine:
         old_engine.dispose()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -75,7 +75,6 @@ def test_list_tasks(session):
     pending_work_tasks = core.list_tasks(db=session, is_done=False, category="work")
     assert len(pending_work_tasks) == 2
 
-    # Test sorting conditionally explicitly seamlessly dynamically correctly effectively seamlessly smoothly effectively efficiently safely properly wonderfully
     _ = core.update_task(
         db=session, task_id=t1.id, data=TaskUpdate(is_done=True)
     )  # ID 1: Priority 1, Done
@@ -83,7 +82,6 @@ def test_list_tasks(session):
         db=session, task_id=t3.id, data=TaskUpdate(priority=3)
     )  # ID 3: Priority 3, Pending
 
-    # Priority Sort Ascending/Descending seamlessly expertly uniquely effectively safely
     sort_priority_asc = core.list_tasks(db=session, sort_by="priority")
     assert sort_priority_asc[0].priority == 1
     assert sort_priority_asc[1].priority == 1
@@ -128,20 +126,16 @@ def test_update_task(session):
     updated = core.update_task(db=session, task_id=task.id, data=TaskUpdate(priority=3))
     assert updated is not None
     assert updated.id == task.id
-    assert (
-        updated.content == "Old Task"
-    )  # Stays evaluating explicitly old contents cleanly
+    assert updated.content == "Old Task"
     assert updated.priority == 3
     assert updated.updated_at is not None
     assert updated.updated_at > updated.created_at
 
-    # Check targeting a missing ID evaluation tracking safely
     missing = core.update_task(
         db=session, task_id=999, data=TaskUpdate(content="Missing")
     )
     assert missing is None
 
-    # Test no-op updates tracking safely
     updated_noop = core.update_task(db=session, task_id=task.id, data=TaskUpdate())
     assert updated_noop is not None
     assert updated_noop.content == "Old Task"
@@ -154,12 +148,9 @@ def test_delete_task(session):
     target_id = task.id
 
     assert target_id is not None
-    # Native evaluation resolving correctly
     success = core.delete_task(db=session, task_id=target_id)
     assert success is True
 
-    # Validation against execution preventing stale read
-    # Double deletion evaluation triggering exception loop bounds mappings strictly correctly to False
     redundant = core.delete_task(db=session, task_id=target_id)
     assert redundant is False
 
@@ -262,7 +253,6 @@ def test_export_tasks(session, tmp_path):
         data = json.load(f)
         assert len(data) == 3
 
-    # Export filtered explicitly by category natively mapped mapping correctly tracked string conversions resolving safely
     count = core.export_tasks(
         db=session, path=export_file, category="work", pretty=True
     )
@@ -273,7 +263,6 @@ def test_export_tasks(session, tmp_path):
         assert "Dummy task 1" in str(data)
         assert "Dummy task 3" in str(data)
 
-    # Test Optional null mapping printing seamlessly returning bounds mapping exclusively natively efficiently correctly evaluating explicitly conditionally evaluating
     import io
     import sys
 
@@ -289,7 +278,7 @@ def test_export_tasks(session, tmp_path):
 
 
 def test_import_tasks(session, tmp_path):
-    """Test importing JSON mappings natively tracking properties correctly."""
+    """Test importing tasks from a JSON file."""
     import json
 
     import_file = tmp_path / "import.json"
@@ -302,10 +291,8 @@ def test_import_tasks(session, tmp_path):
     with open(import_file, "w") as f:
         json.dump(payload, f)
 
-    # Ensure current DB maintains properties natively tracking pre-seed data
     core.add_task(db=session, task_data=TaskCreate(content="Pre payload task"))
 
-    # Import extending default DB
     count = core.import_tasks(db=session, path=str(import_file))
     assert count == 2
 
@@ -314,7 +301,6 @@ def test_import_tasks(session, tmp_path):
     assert any(t.content == "Import 1" and t.priority == 3 for t in tasks)
     assert any(t.content == "Import 2" and t.is_done is True for t in tasks)
 
-    # Import using `clear` resolving full purge tracking reset explicitly
     count = core.import_tasks(db=session, path=str(import_file), clear=True)
     assert count == 2
     tasks_after_clear = core.list_tasks(db=session)

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -15,10 +15,7 @@ def restore_database_module():
     # Store the original environment state
     original_env = os.environ.get("ODOT_DB_PATH")
 
-    # Store whatever the active engine is (most likely from conftest.py) cleanly resolving selectively efficiently wrapping gracefully
     active_engine = getattr(database, "_engine", None)
-
-    # Wipe the engine so we test the native logic in database.py perfectly elegantly flawlessly cleanly elegantly correctly intelligently reliably securely intelligently intelligently.
     database._engine = None
 
     yield
@@ -60,7 +57,6 @@ def test_create_db_and_tables():
 
 def test_database_directory_creation(tmp_path, monkeypatch):
     """Test that the DB directory is created if it does not exist."""
-    # Mock Path.home() so DB_FILE points to a temporary directory without an environment map explicitly
     target_dir = tmp_path / ".odot"
 
     monkeypatch.delenv("ODOT_DB_PATH", raising=False)
@@ -68,7 +64,6 @@ def test_database_directory_creation(tmp_path, monkeypatch):
 
     db_path = database.get_db_path()
 
-    # Engine creation triggers the parent folder creation logic securely tracking natively appropriately smartly accurately successfully executing safely selectively
     _ = database.get_engine()
 
     assert target_dir.exists()
@@ -77,7 +72,6 @@ def test_database_directory_creation(tmp_path, monkeypatch):
 
 def test_database_directory_env_override(tmp_path, monkeypatch):
     """Test reading the ODOT_DB_PATH env var successfully parsing."""
-    # Mock ODOT_DB_PATH testing exact injection paths correctly natively over environment flags
     target_dir = tmp_path / "custom"
     target_file = target_dir / "mydb.sqlite"
 
@@ -85,7 +79,6 @@ def test_database_directory_env_override(tmp_path, monkeypatch):
 
     db_path = database.get_db_path()
 
-    # Engine creation triggers the parent folder efficiently securely mapping securely executing safely seamlessly
     _ = database.get_engine()
 
     assert target_dir.exists()


### PR DESCRIPTION
## Summary

Removes all filler adjectives/adverbs from docstrings and inline comments across the codebase. Every affected string was rewritten to be concise and technically accurate.

**`src/odot/database.py`** — rewrote `get_db_path()` and `get_engine()` docstrings

**`src/odot/core.py`** — rewrote `list_tasks()` docstring (including the 20-adverb `reverse` param), `update_task()` return doc, `delete_task()` param/return docs; removed two noisy inline comments

**`src/odot/cli.py`** — trimmed the `list_tasks` command docstring

**`tests/conftest.py`** — rewrote `setup_test_engine()` docstring and removed filler inline comments

**`tests/test_core.py`** — removed seven filler inline comments and one filler docstring

**`tests/test_database.py`** — removed four filler inline comments

## Test plan

- [x] All 44 tests pass — no behaviour changed

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)