### PR TITLE
docs: add project docs (CLAUDE.md, CONTRIBUTING.md, CHANGELOG.md)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,76 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.3.0] - 2026-05-17
+
+### Added
+
+- `done` and `undo` commands: mark a task complete with `odot done <id>`
+  (or interactively) and revert with `odot undo <id>`.
+- The database now auto-initializes on first use — no need to run
+  `odot init-db` before adding a task.
+
+### Fixed
+
+- Task content and category names are now HTML-escaped in generated reports,
+  preventing XSS in report output.
+
+### Changed
+
+- Dependency updates: sqlmodel 0.0.38, ruff 0.15.9, ty 0.0.29, pytest-cov
+  7.1.0, uv-build, softprops/action-gh-release.
+
+## [0.2.1] - 2026-03-06
+
+### Changed
+
+- Modernized the README: badges, cleaner layout, and updated usage examples.
+
+## [0.2.0] - 2026-03-06
+
+### Added
+
+- Category filtering on the task list via `--category`.
+- `odot search <phrase>` to find tasks by keyword.
+- Clear commands to remove all tasks, or only completed ones.
+- JSON import/export via `odot export` and `odot import`.
+- List sorting by priority, date, category, or status via `--sort`.
+- An `updated_at` timestamp tracking when a task was last modified.
+- Markdown and HTML report generation.
+
+### Fixed
+
+- Renamed the `--pending` flag to `--todo` to resolve a collision with `-p`
+  (priority).
+- Replaced a leaky session generator with explicit `ctx.call_on_close`
+  cleanup.
+
+## [0.1.1] - 2026-03-01
+
+### Added
+
+- `just lock-upgrade` now opens a pull request automatically when dependency
+  updates change the lockfile.
+
+### Changed
+
+- CI hardened to enforce branch protection against direct lockfile upgrades.
+- Dependency updates: sqlmodel 0.0.37, ruff 0.15.4, ty 0.0.19, rich 14.3.3,
+  actions/checkout v6, astral-sh/setup-uv v7.
+
+### Fixed
+
+- Resolved a duplicate auth header that caused the bump-version workflow to
+  fail.
+
+[Unreleased]: https://github.com/jkomalley/odot/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/jkomalley/odot/compare/v0.2.1...v0.3.0
+[0.2.1]: https://github.com/jkomalley/odot/compare/v0.2.0...v0.2.1
+[0.2.0]: https://github.com/jkomalley/odot/compare/v0.1.1...v0.2.0
+[0.1.1]: https://github.com/jkomalley/odot/releases/tag/v0.1.1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,63 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+`odot` is a minimalist, interactive command-line task manager. Python 3.11+, src layout, managed with `uv`, published to PyPI as `odot`.
+
+## Commands
+
+- **Install deps:** `just install` (`uv sync` + `uv run pre-commit install`)
+- **Run the CLI locally:** `just run --help` (`uv run odot --help`)
+- **Run tests:** `just test` (`uv run pytest`)
+- **Run single test:** `uv run pytest tests/test_core.py::test_name -v`
+- **Test with coverage (100% gate):** `just test-cov` (`uv run pytest --cov --cov-fail-under=100`)
+- **Format:** `just format` (`uv run ruff format .`)
+- **Format check:** `just format-check` (`uv run ruff format --check .`)
+- **Lint (auto-fix):** `just lint` (`uv run ruff check --fix .`)
+- **Lint check:** `just lint-check` (`uv run ruff check .`)
+- **Type check:** `just typecheck` (`uv run ty check`)
+- **Everything:** `just check` (format-check + lint-check + typecheck + test-cov)
+- **Clean caches:** `just clean`
+- **Upgrade lockfile:** `just lock-upgrade`
+- **Bump version:** `just bump-version <major|minor|patch|dev|beta|alpha|rc>` (`uv version --bump <part>`)
+
+## Architecture
+
+The project uses a `src/odot/` layout with this module structure:
+
+- `models.py` — SQLModel schemas: `TaskBase` (shared fields: `content`, `priority` 1–3, `category`), `Task` (the `tasks` table, adds `id`, `is_done`, `created_at`, `updated_at`), `TaskCreate` (creation input), `TaskUpdate` (all fields optional, for partial updates).
+- `core.py` — Pure CRUD and business logic (add/get/list/search/update/delete tasks, bulk clean/purge, JSON import/export, Markdown/HTML report generation). Operates on a `Session` passed in by the caller; knows nothing about the CLI or presentation layer.
+- `database.py` — Engine, session, and path management: `get_db_path()` (honors `ODOT_DB_PATH`), `get_engine()` (lazily-created module-level singleton engine), `create_db_and_tables()`.
+- `cli.py` — Typer commands, Rich table/console output, Questionary interactive prompts (used when a required argument like a task ID is omitted).
+
+Key design decisions:
+
+- **The typer/rich/questionary/sqlmodel stack is a deliberate divergence** from the owner's usual argparse/zero-dependency house standard. `odot` is an interactive TUI-style app, and this stack is the pragmatic choice for that — it isn't an oversight.
+- **Categories are free-text and case-sensitive by design.** There is no normalization or a fixed enum; `work` and `Work` are different categories. This is documented behavior, not a bug.
+- **The database lives at `~/.odot/db.sqlite`** unless the `ODOT_DB_PATH` environment variable overrides it. The database and its parent directory are created automatically on first use.
+- **The engine is a process-level singleton** (`database._engine`), created lazily on first `get_engine()` call. Tests replace it with an in-memory engine (see Testing Notes).
+
+## Workflow
+
+- Every feature, fix, or other change gets its own branch and pull request — no direct commits to main.
+- Commits must be atomic and follow Conventional Commits (`feat`, `fix`, `docs`, `chore`, `refactor`, `test`, `ci`, `deps`): one logical change per commit.
+- PRs that resolve an issue reference it with `Closes #N` so it closes automatically on merge.
+- PRs are squash-merged.
+
+## Code Style
+
+- Google-style docstrings (enforced by ruff).
+- Line length: 88 chars.
+- Ruff `select = ["ALL"]` with a pragmatic, curated set of ignores (see `pyproject.toml`).
+- Tests are exempt from docstring and type-annotation rules.
+- Prefer comments that explain *why* code does something, not *what* it does.
+
+## Testing Notes
+
+- 100% branch coverage is a hard gate (`--cov-fail-under=100` in `just test-cov` / `just check`) — every new branch needs a test.
+- Tests use an in-memory SQLite engine (`sqlite:///:memory:` with `StaticPool`) installed via an autouse fixture in `tests/conftest.py`, so tests never touch the real `~/.odot` database.
+- CLI tests use Typer's `CliRunner`.
+- Questionary interactive flows are tested by monkeypatching the questionary calls rather than driving a real TTY.
+- Use `ODOT_DB_PATH` to point at an isolated database path in any test or manual run that needs to exercise `database.py` outside the in-memory fixture.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,133 @@
+# Contributing to odot
+
+Thanks for your interest in improving `odot`. This guide covers everything you
+need to get set up and land a change. For CLI *usage*, see the
+[README](README.md).
+
+## Ways to contribute
+
+- **Report a bug** or **request a feature** by [opening an issue](https://github.com/jkomalley/odot/issues).
+- **Submit a pull request** for a fix or improvement.
+
+For anything large or behavior-changing, please open an issue to discuss the
+approach before investing time in a PR.
+
+## Development setup
+
+**Prerequisites:** Python 3.11+ and [`uv`](https://docs.astral.sh/uv/).
+
+```bash
+git clone https://github.com/jkomalley/odot.git
+cd odot
+uv sync                    # create the venv and install all dependencies
+uv run pre-commit install  # enable the git hooks
+```
+
+`just install` does the same two steps in one command.
+
+## Project layout
+
+The package uses a `src/` layout. Each module has a single, focused
+responsibility:
+
+| Module | Responsibility |
+| --- | --- |
+| `models.py` | SQLModel schemas: `TaskBase`, `Task` (the `tasks` table), `TaskCreate`, `TaskUpdate`. |
+| `core.py` | Pure CRUD and business logic. Takes a `Session`; knows nothing about the CLI. |
+| `database.py` | Engine/session/path management, including the `ODOT_DB_PATH` override and the engine singleton. |
+| `cli.py` | Typer commands, Rich output, Questionary interactive prompts. |
+
+## Running checks
+
+The repo uses [`just`](https://github.com/casey/just) as a task runner. Run
+everything before pushing:
+
+```bash
+just check   # format-check + lint-check + typecheck + test-cov
+```
+
+Or run individual tasks:
+
+```bash
+just format        # ruff format
+just format-check  # ruff format --check
+just lint          # ruff check --fix
+just lint-check    # ruff check
+just typecheck     # ty check
+just test          # pytest
+just test-cov      # pytest with 100% coverage enforcement
+```
+
+Each task maps to a plain `uv run …` command, so you can run them directly if
+you'd rather not install `just`.
+
+## Coding standards
+
+- **Style & linting:** [`ruff`](https://docs.astral.sh/ruff/) with `select = ["ALL"]` and a curated
+  set of pragmatic ignores (see `pyproject.toml`). Run `just format` and `just lint`
+  before committing.
+- **Type checking:** the codebase is fully typed; `just typecheck` (`ty`) must pass.
+- **Docstrings:** Google-style, on every public function and class.
+- **Comments:** explain *why*, not *what*. Lean toward documenting non-obvious
+  decisions; skip comments that merely restate the code.
+- **Line length:** 88 characters.
+
+### Testing
+
+- **100% branch coverage is required.** Every new code path needs a test; check
+  with `just test-cov`.
+- Tests must not touch the real `~/.odot` database — use the in-memory SQLite
+  fixtures in `tests/conftest.py`, or set `ODOT_DB_PATH` for isolation when a
+  test needs an on-disk file.
+- CLI tests use Typer's `CliRunner`; interactive (Questionary) flows are tested
+  by monkeypatching the prompt calls.
+
+## Pull requests
+
+- Branch off `main`; one logical change per PR.
+- Keep commits atomic and use [Conventional Commits](https://www.conventionalcommits.org/)
+  (`feat`, `fix`, `docs`, `chore`, `refactor`, `test`, `ci`, `deps`).
+- Include tests for any new or changed behavior.
+- Reference the issue a PR resolves with `Closes #N` so it closes automatically.
+- Make sure `just check` passes cleanly before you open the PR.
+- PRs are squash-merged.
+
+CI runs the full check suite against Python 3.11–3.14 on every pull request.
+
+## Releasing
+
+Releases are published to PyPI automatically: the release workflow fires when
+CI passes on `main` and publishes whenever `pyproject.toml`'s version isn't
+already on PyPI. So a release is just a version bump merged to `main` — once
+it lands, the workflow builds the package, publishes it to PyPI, tags the
+commit, and drafts a GitHub release.
+
+Choose the bump from the changes since the **last release tag**, not just your
+latest work:
+
+```bash
+git log "$(git describe --tags --abbrev=0)"..HEAD --oneline
+```
+
+Map the conventional-commit types in that range to a [semver](https://semver.org/)
+bump and apply it with `just`:
+
+| Changes since last release | Bump | Command |
+| --- | --- | --- |
+| Any `feat:` | minor | `just bump-version minor` |
+| Only `fix:` / `docs:` / `chore:` | patch | `just bump-version patch` |
+| A breaking change (`feat!:`, `BREAKING CHANGE`) | major¹ | `just bump-version major` |
+
+¹ While the project is pre-1.0, breaking changes are released as a **minor**
+bump per semver's 0.x convention.
+
+Open the bump as its own PR. The `version-guard` CI job enforces this: it fails
+any release PR whose bump is too small for the commits since the last release
+(for example, shipping a `feat:` in a patch). Features merged to `main` without
+a release accumulate, so the bump must account for all of them — not just the
+most recent change.
+
+## License
+
+By contributing, you agree that your contributions are licensed under the
+project's [MIT License](LICENSE).

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Kyle
+Copyright (c) 2026 Kyle O'Malley
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -110,6 +110,11 @@ just test-cov      # enforce 100% coverage
 just check         # ruff + ty + tests
 ```
 
+## Contributing
+
+Contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for development
+setup, project layout, and the conventions this repo follows.
+
 ## License
 
-[MIT](LICENSE)
+Released under the [MIT License](LICENSE).


### PR DESCRIPTION
Adds the project documentation set and two small hygiene fixes. No source code, tests, configs, or workflows are touched.

## CLAUDE.md (new)
Guidance for Claude Code, following the envbool/dsz structure: project overview (Python 3.11+, src layout, uv-managed, PyPI package `odot`), the full `just` recipe list with `uv run` equivalents, module-by-module architecture (`models.py` / `core.py` / `database.py` / `cli.py`), key design decisions (the typer/rich/questionary/sqlmodel stack as a deliberate divergence from the argparse/zero-dependency house standard; free-text case-sensitive categories; `~/.odot/db.sqlite` with `ODOT_DB_PATH` override; the lazy engine singleton), workflow conventions, code style, and testing notes (100% branch coverage gate, in-memory StaticPool fixture, CliRunner, monkeypatched questionary flows).

## CONTRIBUTING.md (new)
Contributor guide modeled on envbool's: ways to contribute, dev setup (`uv sync` + `uv run pre-commit install`), project layout table, running checks via `just`, coding standards (ruff ALL, ty, Google docstrings, 88 cols, why-comments), testing standards (100% coverage, isolation rules), PR conventions (atomic conventional commits, one branch per change, squash merge), and a Releasing section documenting the conventional-commit → semver bump mapping, the `version-guard` CI check, `just bump-version <part>`, and the auto-publish-on-main CD flow (publish to PyPI, tag, draft GitHub release).

## CHANGELOG.md (new)
Keep-a-Changelog 1.1.0 format seeded from the real GitHub releases: v0.1.1 (2026-03-01), v0.2.0 and v0.2.1 (2026-03-06), v0.3.0 (2026-05-17), with an `[Unreleased]` section and compare-link footer.

## README.md
Adds a Contributing section linking CONTRIBUTING.md and rewords the License section to match the house README tone. No other changes.

## LICENSE
Copyright line corrected from "Kyle" to "Kyle O'Malley".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YYUNdJDjHY9GAktZ3QccD5