### PR TITLE
refactor: core API cleanups and test gap closure

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,9 +104,6 @@ convention = "google"
 "src/odot/cli.py" = [
     "T201",   # print() is a valid output mechanism for the CLI
 ]
-"src/odot/core.py" = [
-    "T201",   # print() streams JSON export to stdout
-]
 "tests/test_cli_subprocess.py" = [
     "S603",   # subprocess call with controlled input is safe here
 ]

--- a/src/odot/core.py
+++ b/src/odot/core.py
@@ -222,8 +222,12 @@ def export_tasks(
     indent = 2 if pretty else None
 
     if path is None:
-        json.dump(export_data, output or sys.stdout, indent=indent)
+        stream = output or sys.stdout
+        json.dump(export_data, stream, indent=indent)
+        # Match the old print() behavior so shell prompts land on a new line.
+        stream.write("\n")
     else:
+        # File output deliberately has no trailing newline (unchanged behavior).
         file_path = Path(path)
         with file_path.open("w", encoding="utf-8") as f:
             json.dump(export_data, f, indent=indent)

--- a/src/odot/core.py
+++ b/src/odot/core.py
@@ -1,14 +1,19 @@
 """Core library logic (CRUD operations)."""
 
 import json
+import sys
 from datetime import UTC, datetime
 from html import escape
 from itertools import groupby
 from pathlib import Path
+from typing import TextIO
 
 from sqlmodel import Session, col, delete, select
 
 from odot.models import Task, TaskCreate, TaskUpdate
+
+#: Fields accepted by `list_tasks`'s `sort_by` parameter (case-insensitive).
+VALID_SORT_FIELDS = ("priority", "date", "category", "status")
 
 
 def add_task(db: Session, task_data: TaskCreate) -> Task:
@@ -54,11 +59,15 @@ def list_tasks(
         db: SQLModel Session instance.
         is_done: Filter by completion status if set; otherwise returns all tasks.
         category: Filter by category if set; otherwise returns all tasks.
-        sort_by: Field to sort by ('priority', 'date', 'category', 'status').
+        sort_by: Field to sort by, one of `VALID_SORT_FIELDS`
+            ('priority', 'date', 'category', 'status'). Case-insensitive.
         reverse: If True, sort descending.
 
     Returns:
         A list of matching Task schemas.
+
+    Raises:
+        ValueError: If `sort_by` is set but is not one of `VALID_SORT_FIELDS`.
     """
     statement = select(Task)
 
@@ -68,6 +77,13 @@ def list_tasks(
         statement = statement.where(col(Task.category) == category)
 
     if sort_by:
+        normalized = sort_by.lower()
+        if normalized not in VALID_SORT_FIELDS:
+            msg = (
+                f"Invalid sort field: {sort_by!r}. Must be one of {VALID_SORT_FIELDS}."
+            )
+            raise ValueError(msg)
+
         field_map = {
             "priority": Task.priority,
             "date": Task.created_at,
@@ -75,16 +91,20 @@ def list_tasks(
             "status": Task.is_done,
         }
 
-        target_field = field_map.get(sort_by.lower())
-        if target_field:
-            ordering = col(target_field).desc() if reverse else col(target_field).asc()
-            statement = statement.order_by(ordering)
+        target_field = field_map[normalized]
+        ordering = col(target_field).desc() if reverse else col(target_field).asc()
+        statement = statement.order_by(ordering)
 
     return list(db.exec(statement).all())
 
 
 def search_tasks(db: Session, phrase: str) -> list[Task]:
     """Search tasks by content phrase.
+
+    Matching is explicitly case-insensitive: both the column and the search
+    phrase are lowered via SQL `lower()` before comparison, rather than
+    relying on SQLite's default `LIKE` case-folding (which is ASCII-only and
+    an implementation detail we don't want to depend on implicitly).
 
     Args:
         db: SQLModel Session instance.
@@ -93,7 +113,7 @@ def search_tasks(db: Session, phrase: str) -> list[Task]:
     Returns:
         A list of matching Task schemas.
     """
-    statement = select(Task).where(col(Task.content).contains(phrase))
+    statement = select(Task).where(col(Task.content).icontains(phrase))
     return list(db.exec(statement).all())
 
 
@@ -180,34 +200,33 @@ def export_tasks(
     is_done: bool | None = None,
     category: str | None = None,
     pretty: bool = False,
+    output: TextIO | None = None,
 ) -> int:
-    """Export tasks to a JSON file.
+    """Export tasks to a JSON file, or to a stream when no path is given.
 
     Args:
         db: SQLModel Session instance.
-        path: File path to save the JSON output.
+        path: File path to save the JSON output. If None, JSON is written to
+            `output` instead.
         is_done: Optional filter by completion status.
         category: Optional filter by category.
         pretty: Whether to format the JSON string with indentation.
+        output: Stream to write JSON to when `path` is None. Defaults to
+            `sys.stdout`. Ignored if `path` is provided.
 
     Returns:
         The total number of exported records.
     """
     tasks = list_tasks(db=db, is_done=is_done, category=category)
     export_data = [task.model_dump(mode="json") for task in tasks]
+    indent = 2 if pretty else None
 
     if path is None:
-        if pretty:
-            print(json.dumps(export_data, indent=2))
-        else:
-            print(json.dumps(export_data))
+        json.dump(export_data, output or sys.stdout, indent=indent)
     else:
         file_path = Path(path)
         with file_path.open("w", encoding="utf-8") as f:
-            if pretty:
-                json.dump(export_data, f, indent=2)
-            else:
-                json.dump(export_data, f)
+            json.dump(export_data, f, indent=indent)
 
     return len(tasks)
 

--- a/src/odot/database.py
+++ b/src/odot/database.py
@@ -39,6 +39,27 @@ def get_engine() -> Engine:
     return _engine
 
 
+def set_engine(engine: Engine | None) -> None:
+    """Override the module-level singleton engine.
+
+    This is the supported way to inject a test engine (or clear it) without
+    reaching into the private ``_engine`` module variable directly.
+
+    Args:
+        engine: The engine to install as the active singleton, or None.
+    """
+    global _engine  # noqa: PLW0603  # module-level singleton engine, swapped in tests
+    _engine = engine
+
+
+def reset_engine() -> None:
+    """Clear the module-level singleton engine.
+
+    The next call to `get_engine` will create a fresh engine.
+    """
+    set_engine(None)
+
+
 def create_db_and_tables() -> None:
     """Create the database tables.
 

--- a/src/odot/models.py
+++ b/src/odot/models.py
@@ -10,11 +10,21 @@ class TaskBase(SQLModel):
 
     content: str = Field(index=True, min_length=1, max_length=255)
     priority: int = Field(default=1, ge=1, le=3, description="Priority from 1 to 3")
-    category: str = Field(default="general", index=True)
+    category: str = Field(
+        default="general",
+        index=True,
+        description="Free-text category label; matching is case-sensitive by design.",
+    )
 
 
 class TaskCreate(TaskBase):
-    """Used for type hinting and structural alignment during task creation."""
+    """Schema used to validate input when creating a new task.
+
+    This is the intentional seam between untrusted input (CLI args, imported
+    JSON, etc.) and the ``Task`` table model. It currently mirrors
+    ``TaskBase`` with no additional fields, but exists so creation-specific
+    validation or fields can be added later without touching ``Task`` itself.
+    """
 
 
 class TaskUpdate(SQLModel):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,8 @@ import pytest
 from sqlmodel import Session, SQLModel, create_engine
 from sqlmodel.pool import StaticPool
 
+from odot import database
+
 # Use in-memory SQLite for testing to ensure speed and isolation
 sqlite_url = "sqlite:///:memory:"
 
@@ -23,14 +25,9 @@ def engine_fixture():
 @pytest.fixture(autouse=True)
 def setup_test_engine(engine):
     """Swap the global engine for the in-memory test engine around each test."""
-    from odot import database
-
-    old_engine = database._engine
-    database._engine = engine
+    database.set_engine(engine)
     yield
-    database._engine = old_engine
-    if old_engine:
-        old_engine.dispose()
+    database.reset_engine()
 
 
 @pytest.fixture(name="session")

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -297,7 +297,10 @@ def test_export_tasks(session, tmp_path):
     captured_output = io.StringIO()
     count = core.export_tasks(db=session, pretty=False, output=captured_output)
     assert count == 3
-    data = json.loads(captured_output.getvalue())
+    written = captured_output.getvalue()
+    # Stream output ends with a newline, matching the old print() behavior.
+    assert written.endswith("\n")
+    data = json.loads(written)
     assert len(data) == 3
 
 
@@ -310,7 +313,9 @@ def test_export_tasks_defaults_to_stdout(session, monkeypatch):
 
     count = core.export_tasks(db=session)
     assert count == 1
-    data = json.loads(captured_output.getvalue())
+    written = captured_output.getvalue()
+    assert written.endswith("\n")
+    data = json.loads(written)
     assert len(data) == 1
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,5 +1,10 @@
 """Unit tests for core logic CRUD operations."""
 
+import io
+import json
+
+import pytest
+
 from odot import core
 from odot.models import Task, TaskCreate, TaskUpdate
 
@@ -114,9 +119,14 @@ def test_list_tasks(session):
     assert sort_category[0].category == "personal"
     assert sort_category[-1].category == "work"
 
-    # An unrecognized sort field is ignored and returns tasks unsorted.
-    unknown_sort = core.list_tasks(db=session, sort_by="nonexistent")
-    assert len(unknown_sort) == len(sort_category)
+
+def test_list_tasks_invalid_sort_raises(session):
+    """Test that an invalid sort_by value raises ValueError (see #47, #50)."""
+    core.add_task(db=session, task_data=TaskCreate(content="A", priority=2))
+    core.add_task(db=session, task_data=TaskCreate(content="B", priority=1))
+
+    with pytest.raises(ValueError, match="Invalid sort field"):
+        core.list_tasks(db=session, sort_by="nonexistent")
 
 
 def test_update_task(session):
@@ -184,6 +194,24 @@ def test_search_tasks(session):
     assert len(results) == 0
 
 
+def test_search_tasks_mixed_case(session):
+    """Test that mixed-case phrases match regardless of stored casing."""
+    core.add_task(db=session, task_data=TaskCreate(content="Review PR Feedback"))
+
+    # Mixed-case phrase against mixed-case content
+    results = core.search_tasks(db=session, phrase="pR fEEdback")
+    assert len(results) == 1
+    assert results[0].content == "Review PR Feedback"
+
+    # All-lowercase phrase
+    results = core.search_tasks(db=session, phrase="review")
+    assert len(results) == 1
+
+    # All-uppercase phrase
+    results = core.search_tasks(db=session, phrase="REVIEW")
+    assert len(results) == 1
+
+
 def test_delete_completed_tasks(session):
     """Test dropping only records marked as done."""
     t1 = core.add_task(db=session, task_data=TaskCreate(content="Dummy task 1"))
@@ -246,8 +274,6 @@ def test_export_tasks(session, tmp_path):
     assert t2.id is not None
     core.update_task(db=session, task_id=t2.id, data=TaskUpdate(is_done=True))
 
-    import json
-
     export_file = tmp_path / "export.json"
 
     # Export all
@@ -267,24 +293,29 @@ def test_export_tasks(session, tmp_path):
         assert "Dummy task 1" in str(data)
         assert "Dummy task 3" in str(data)
 
-    import io
-    import sys
+    # Injectable output stream (no path): defaults to sys.stdout when omitted.
+    captured_output = io.StringIO()
+    count = core.export_tasks(db=session, pretty=False, output=captured_output)
+    assert count == 3
+    data = json.loads(captured_output.getvalue())
+    assert len(data) == 3
+
+
+def test_export_tasks_defaults_to_stdout(session, monkeypatch):
+    """Test that export_tasks writes to sys.stdout when output is not given."""
+    core.add_task(db=session, task_data=TaskCreate(content="Dummy task"))
 
     captured_output = io.StringIO()
-    sys.stdout = captured_output
-    try:
-        count = core.export_tasks(db=session, pretty=False)
-        assert count == 3
-        data = json.loads(captured_output.getvalue())
-        assert len(data) == 3
-    finally:
-        sys.stdout = sys.__stdout__
+    monkeypatch.setattr("sys.stdout", captured_output)
+
+    count = core.export_tasks(db=session)
+    assert count == 1
+    data = json.loads(captured_output.getvalue())
+    assert len(data) == 1
 
 
 def test_import_tasks(session, tmp_path):
     """Test importing tasks from a JSON file."""
-    import json
-
     import_file = tmp_path / "import.json"
 
     # Write some dummy payload explicitly
@@ -309,6 +340,53 @@ def test_import_tasks(session, tmp_path):
     assert count == 2
     tasks_after_clear = core.list_tasks(db=session)
     assert len(tasks_after_clear) == 2
+
+
+def test_import_tasks_missing_content(session, tmp_path):
+    """Test that importing JSON with a missing content key raises KeyError."""
+    bad_file = tmp_path / "bad_import.json"
+    payload = [{"priority": 2, "category": "work"}]  # missing content
+    bad_file.write_text(json.dumps(payload))
+
+    with pytest.raises(KeyError):
+        core.import_tasks(db=session, path=str(bad_file))
+
+    # Nothing should have been committed before the failure.
+    assert core.list_tasks(db=session) == []
+
+
+def test_import_tasks_empty_array(session, tmp_path):
+    """Test that importing an empty JSON array adds no tasks."""
+    empty_file = tmp_path / "empty.json"
+    empty_file.write_text("[]")
+
+    count = core.import_tasks(db=session, path=str(empty_file))
+    assert count == 0
+    assert core.list_tasks(db=session) == []
+
+
+def test_import_tasks_ignores_unknown_fields(session, tmp_path):
+    """Test that extra/unexpected JSON fields are silently ignored."""
+    extra_file = tmp_path / "extra_fields.json"
+    payload = [
+        {
+            "content": "Task with extras",
+            "priority": 2,
+            "category": "work",
+            "unexpected_field": "should be ignored",
+            "another_bogus_key": 123,
+        }
+    ]
+    extra_file.write_text(json.dumps(payload))
+
+    count = core.import_tasks(db=session, path=str(extra_file))
+    assert count == 1
+
+    tasks = core.list_tasks(db=session)
+    assert len(tasks) == 1
+    assert tasks[0].content == "Task with extras"
+    assert tasks[0].priority == 2
+    assert not hasattr(tasks[0], "unexpected_field")
 
 
 def test_generate_markdown_report():

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -4,37 +4,26 @@ import os
 from pathlib import Path
 
 import pytest
+from sqlmodel import create_engine
 
 from odot import database
 
 
 @pytest.fixture(autouse=True)
-def restore_database_module():
-    """Ensure database.py is cleanly reloaded and independent for each test."""
-    import importlib
-
-    # Store the original environment state
+def isolate_engine():
+    """Ensure each test starts with no engine configured and restores env vars."""
     original_env = os.environ.get("ODOT_DB_PATH")
 
-    active_engine = getattr(database, "_engine", None)
-    database._engine = None
+    database.reset_engine()
 
     yield
 
-    # Restore the environment completely
     if original_env is not None:
         os.environ["ODOT_DB_PATH"] = original_env
     else:
         os.environ.pop("ODOT_DB_PATH", None)
 
-    engine = getattr(database, "_engine", None)
-    if engine is not None and engine != active_engine:
-        engine.dispose()
-
-    database._engine = active_engine
-
-    # Reload the module to restore to original test state universally
-    importlib.reload(database)
+    database.reset_engine()
 
 
 def test_database_url_and_engine():
@@ -42,18 +31,18 @@ def test_database_url_and_engine():
     db_file = database.get_db_path()
     assert db_file is not None
     assert isinstance(db_file, Path)
-    assert not database._engine  # Should be none originally
 
     engine = database.get_engine()
     assert engine is not None
     assert str(engine.url).startswith("sqlite:///")
-    assert database._engine is not None
+    engine.dispose()
 
 
 def test_create_db_and_tables():
     """Test table creation against the real engine."""
     # We can invoke the real engine execution without failing
     database.create_db_and_tables()
+    database.get_engine().dispose()
 
 
 def test_database_directory_creation(tmp_path, monkeypatch):
@@ -65,10 +54,11 @@ def test_database_directory_creation(tmp_path, monkeypatch):
 
     db_path = database.get_db_path()
 
-    _ = database.get_engine()
+    engine = database.get_engine()
 
     assert target_dir.exists()
     assert db_path.parent == target_dir
+    engine.dispose()
 
 
 def test_database_directory_env_override(tmp_path, monkeypatch):
@@ -80,7 +70,33 @@ def test_database_directory_env_override(tmp_path, monkeypatch):
 
     db_path = database.get_db_path()
 
-    _ = database.get_engine()
+    engine = database.get_engine()
 
     assert target_dir.exists()
     assert db_path == target_file
+    engine.dispose()
+
+
+def test_set_engine_overrides_singleton():
+    """Test that set_engine installs a specific engine as the singleton."""
+    custom_engine = create_engine("sqlite:///:memory:")
+
+    database.set_engine(custom_engine)
+
+    assert database.get_engine() is custom_engine
+
+    custom_engine.dispose()
+
+
+def test_reset_engine_clears_singleton():
+    """Test that reset_engine forces get_engine to create a fresh engine."""
+    first_engine = database.get_engine()
+
+    database.reset_engine()
+
+    second_engine = database.get_engine()
+
+    assert first_engine is not second_engine
+
+    first_engine.dispose()
+    second_engine.dispose()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,6 +1,8 @@
 """Tests for data models."""
 
 import pytest
+from hypothesis import given
+from hypothesis import strategies as st
 from pydantic import ValidationError
 
 from odot.models import Task, TaskCreate, TaskUpdate
@@ -60,3 +62,91 @@ def test_task_update_optional_fields():
     assert update_partial.content is None
     assert update_partial.priority == 3
     assert update_partial.is_done is True
+
+
+def test_task_update_invalid_content():
+    """Test TaskUpdate content length validation (see #49)."""
+    with pytest.raises(ValidationError):
+        TaskUpdate(content="")  # min_length=1
+
+    with pytest.raises(ValidationError):
+        TaskUpdate(content="a" * 256)  # max_length=255
+
+
+def test_task_update_invalid_priority():
+    """Test TaskUpdate priority range validation (see #49)."""
+    with pytest.raises(ValidationError):
+        TaskUpdate(priority=0)  # ge=1
+
+    with pytest.raises(ValidationError):
+        TaskUpdate(priority=4)  # le=3
+
+
+def test_task_update_valid_partial_updates():
+    """Test that valid partial TaskUpdate values are accepted (see #49)."""
+    content_only = TaskUpdate(content="Updated content")
+    assert content_only.content == "Updated content"
+    assert content_only.priority is None
+
+    priority_only = TaskUpdate(priority=1)
+    assert priority_only.priority == 1
+
+    boundary_priority = TaskUpdate(priority=3)
+    assert boundary_priority.priority == 3
+
+    category_only = TaskUpdate(category="errands")
+    assert category_only.category == "errands"
+
+    done_only = TaskUpdate(is_done=False)
+    assert done_only.is_done is False
+
+
+# --------------------------------------------------------------------------- #
+# Property-based tests (Hypothesis)
+# --------------------------------------------------------------------------- #
+
+
+@given(content=st.text(min_size=1, max_size=255))
+def test_task_create_content_within_bounds_accepted(content):
+    """Any content within [1, 255] chars should be accepted by TaskCreate."""
+    task = TaskCreate(content=content)
+    assert task.content == content
+
+
+@given(content=st.text(min_size=256, max_size=300))
+def test_task_create_content_over_max_rejected(content):
+    """Content longer than 255 chars should always be rejected."""
+    with pytest.raises(ValidationError):
+        TaskCreate(content=content)
+
+
+@given(priority=st.integers(min_value=1, max_value=3))
+def test_task_create_priority_within_bounds_accepted(priority):
+    """Any priority within [1, 3] should be accepted by TaskCreate."""
+    task = TaskCreate(content="valid content", priority=priority)
+    assert task.priority == priority
+
+
+@given(
+    priority=st.integers(min_value=-100, max_value=100).filter(lambda p: p < 1 or p > 3)
+)
+def test_task_create_priority_out_of_bounds_rejected(priority):
+    """Any priority outside [1, 3] should always be rejected."""
+    with pytest.raises(ValidationError):
+        TaskCreate(content="valid content", priority=priority)
+
+
+@given(priority=st.integers(min_value=1, max_value=3))
+def test_task_update_priority_within_bounds_accepted(priority):
+    """Any priority within [1, 3] should be accepted by TaskUpdate."""
+    update = TaskUpdate(priority=priority)
+    assert update.priority == priority
+
+
+@given(
+    priority=st.integers(min_value=-100, max_value=100).filter(lambda p: p < 1 or p > 3)
+)
+def test_task_update_priority_out_of_bounds_rejected(priority):
+    """Any priority outside [1, 3] should always be rejected by TaskUpdate."""
+    with pytest.raises(ValidationError):
+        TaskUpdate(priority=priority)


### PR DESCRIPTION
## Summary

Core refactors and test-gap closures for `src/odot/core.py`, `src/odot/database.py`, and `src/odot/models.py`. All public core/database signature changes are backward-compatible (new params default to `None`/unset), so `src/odot/cli.py` and `tests/test_cli.py` are **unmodified**.

Closes #44
Closes #47
Closes #48
Closes #49
Closes #50
Closes #51
Closes #52

### Per-issue summary

**Closes #44** — module-level imports in `core.py`. Verified: this was already fully addressed by a prior tooling migration PR. No function-local imports remain in `core.py` except the intentionally-commented circular-import guard in `database.py` (`create_db_and_tables`), which is left as-is.

**Closes #47** — shared sort validation. Added `core.VALID_SORT_FIELDS = ("priority", "date", "category", "status")` and made `core.list_tasks` raise `ValueError` for an unrecognized `sort_by` instead of silently skipping the sort. Verified no internal core.py call site (`export_tasks`, report generation) passes an unvalidated `sort_by` — `export_tasks` never passes `sort_by` to `list_tasks`, and report generation in `core.py` takes an already-fetched `list[Task]`, so `cli.py`'s pre-validation is the only place `sort_by` reaches `list_tasks` with user input, and CLI behavior is unchanged.

**Closes #48** — injectable export output. `core.export_tasks` now accepts `output: TextIO | None = None`; when `path` is `None` it writes JSON via `json.dump(export_data, output or sys.stdout, indent=...)` instead of `print()`. Removed the now-unneeded `"src/odot/core.py" = ["T201"]` per-file-ignore from `pyproject.toml`. `cli.py`'s `export_cmd` never passes `output`, so behavior (writing to real stdout) is unchanged.

**Closes #52** — public engine API. Added `database.set_engine(engine)` and `database.reset_engine()`. Rewrote `tests/conftest.py`'s `setup_test_engine` fixture and all of `tests/test_database.py` to use them — no more direct `database._engine` access and no `importlib.reload()`. `tests/test_cli.py` was not touched; it relies on the `session` fixture and monkeypatches `odot.cli.Session` directly, both of which are preserved with identical names/semantics.

**Search case-insensitivity** — `search_tasks` now uses `col(Task.content).icontains(phrase)` (explicit `lower()`-based comparison) instead of relying on SQLite's default `LIKE` case-folding, which is ASCII-only and was an implicit dependency. Docstring updated to explain this. Added `test_search_tasks_mixed_case` covering mixed/upper/lower-case phrase matching.

**Models docs** — `TaskCreate` now has a docstring explaining it's the intentional create-schema seam (mirrors `TaskBase`, no new fields today, exists for future extensibility). `category` field description now notes it is free-text and case-sensitive by design.

**Closes #49** — added `TaskUpdate` validation tests: empty content rejected, oversized content (>255 chars) rejected, out-of-range priority (0 and 4) rejected, and valid partial updates accepted.

**Closes #50** — added `test_list_tasks_invalid_sort_raises`, asserting `core.list_tasks(sort_by="nonexistent")` raises `ValueError` (updated per the issue's note that this supersedes the original silent-ignore assertion once #47 lands).

**Closes #51** — added `core.import_tasks` edge-case tests: JSON record missing the required `content` key (raises `KeyError`, and confirms no partial commit occurred), an empty JSON array (returns 0, no tasks added), and records with extra/unknown fields (silently ignored via `TaskCreate`).

**Hypothesis property tests** — added to `tests/test_models.py`: `TaskCreate`/`TaskUpdate` content length (1..255 accepted, >255 rejected) and priority (1..3 accepted, outside rejected) bounds, using the default Hypothesis profile with simple `st.text`/`st.integers` strategies for speed.

## Test plan

- [x] `uv sync`
- [x] `just check` fully green (format, lint, ty, `pytest --cov --cov-fail-under=100`) — 63 tests passed, 100% branch coverage
- [x] `tests/test_cli.py` byte-identical to `main` (`git diff --stat main -- tests/test_cli.py` empty) and passing
- [x] `grep -rn "_engine" tests/` shows no direct private (`database._engine`) access, only public API calls and unrelated local variable names
- [x] `uv run pre-commit run --all-files` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YYUNdJDjHY9GAktZ3QccD5