### PR TITLE
feat: CLI presentation refactor and UX improvements

### DIFF
--- a/src/odot/_format.py
+++ b/src/odot/_format.py
@@ -1,0 +1,134 @@
+"""Presentation helpers shared by CLI commands.
+
+Kept separate from `cli.py` so table rendering, time formatting, and text
+highlighting can be unit tested as pure functions without going through
+Typer's `CliRunner`.
+"""
+
+import re
+from datetime import datetime, timedelta
+
+from rich.table import Table
+from rich.text import Text
+
+from odot.models import Task
+
+#: Rich markup for each priority level, paired with a short text label so the
+#: meaning survives even without color (e.g. piped output, colorblind users).
+_PRIORITY_DISPLAY = {
+    1: "[dim]● Low[/dim]",
+    2: "[yellow]●● Med[/yellow]",
+    3: "[bold red]●●● High[/bold red]",
+}
+
+
+def priority_display(priority: int) -> str:
+    """Render a task priority as a colored dot indicator with a text label.
+
+    Args:
+        priority: Priority value (expected 1-3, but any int falls back to
+            its plain string form so malformed data never crashes rendering).
+
+    Returns:
+        Rich markup string for the priority, or the bare number if it falls
+        outside the known 1-3 range.
+    """
+    return _PRIORITY_DISPLAY.get(priority, str(priority))
+
+
+def highlight_match(content: str, phrase: str) -> Text:
+    """Highlight every case-insensitive occurrence of `phrase` within `content`.
+
+    Uses the `rich.text.Text` API rather than f-string markup injection so
+    that content containing literal `[...]` sequences (which would otherwise
+    be interpreted as rich markup) renders as plain text everywhere except
+    the highlighted span.
+
+    Args:
+        content: The full task content to render.
+        phrase: The search phrase to highlight. If empty, no highlighting
+            is applied.
+
+    Returns:
+        A `Text` object with matching spans styled `bold yellow`.
+    """
+    text = Text(content)
+    if not phrase:
+        return text
+
+    for match in re.finditer(re.escape(phrase), content, re.IGNORECASE):
+        text.stylize("bold yellow", match.start(), match.end())
+    return text
+
+
+def render_task_table(
+    tasks: list[Task], *, title: str, highlight: str | None = None
+) -> Table:
+    """Build a Rich table for a list of tasks.
+
+    Shared by `list` and `search` so both commands render identical columns
+    and styling; `search` additionally highlights the matched phrase.
+
+    Args:
+        tasks: Tasks to render, one per row.
+        title: Table title.
+        highlight: Optional phrase to highlight within each row's content
+            (used by `search`; `list` omits it).
+
+    Returns:
+        A populated Rich `Table` ready to print.
+    """
+    table = Table(title=title)
+    table.add_column("ID", justify="right", style="cyan", no_wrap=True)
+    table.add_column("Status", style="green")
+    table.add_column("Priority", justify="right")
+    table.add_column("Category", style="blue")
+    table.add_column("Content")
+
+    for task in tasks:
+        status_str = "[green]✓[/]" if task.is_done else "[yellow]○[/]"
+        content: str | Text = (
+            highlight_match(task.content, highlight) if highlight else task.content
+        )
+        table.add_row(
+            str(task.id),
+            status_str,
+            priority_display(task.priority),
+            task.category,
+            content,
+        )
+
+    return table
+
+
+#: Ordered (threshold, formatter) buckets for relative_time, smallest first.
+_RELATIVE_TIME_BUCKETS = (
+    (timedelta(minutes=1), lambda _delta: "just now"),
+    (timedelta(hours=1), lambda delta: f"{int(delta.total_seconds() // 60)}m ago"),
+    (timedelta(days=1), lambda delta: f"{int(delta.total_seconds() // 3600)}h ago"),
+    (timedelta(days=7), lambda delta: f"{delta.days}d ago"),
+)
+
+
+def relative_time(dt: datetime, now: datetime | None = None) -> str:
+    """Format a datetime as a short human-relative string (e.g. "2h ago").
+
+    Args:
+        dt: The timestamp to describe, relative to `now`.
+        now: Reference point; defaults to `datetime.now()` in `dt`'s
+            timezone (or naive local time if `dt` is naive) so callers can
+            pass a fixed value for deterministic tests.
+
+    Returns:
+        A short relative-time string: "just now", "Xm ago", "Xh ago",
+        "Xd ago", or "Xw ago" for anything a week or older.
+    """
+    if now is None:
+        now = datetime.now(dt.tzinfo)
+
+    delta = now - dt
+    for threshold, formatter in _RELATIVE_TIME_BUCKETS:
+        if delta < threshold:
+            return formatter(delta)
+
+    return f"{delta.days // 7}w ago"

--- a/src/odot/cli.py
+++ b/src/odot/cli.py
@@ -2,6 +2,7 @@
 
 import importlib.metadata
 import json
+from enum import StrEnum
 from pathlib import Path
 from typing import Annotated, Any
 
@@ -13,12 +14,34 @@ from rich.table import Table
 from sqlmodel import Session
 
 from odot import core, database
-from odot.models import TaskCreate, TaskUpdate
+from odot._format import relative_time, render_task_table
+from odot.models import Task, TaskCreate, TaskUpdate
 
 DATETIME_FORMAT = "%Y-%m-%d %H:%M:%S"
 
+
+class SortField(StrEnum):
+    """Fields accepted by the --sort option on `list` and `report`.
+
+    Mirrors `core.VALID_SORT_FIELDS`; a test asserts the two stay in sync.
+    Using an Enum as the Typer option type moves validation to parse time,
+    so an invalid value is rejected by Typer itself (usage error, exit 2)
+    instead of by hand-rolled checks inside each command.
+    """
+
+    PRIORITY = "priority"
+    DATE = "date"
+    CATEGORY = "category"
+    STATUS = "status"
+
+
+# invoke_without_command lets `odot` with no subcommand fall through to
+# main_callback instead of auto-printing help (see #61); help remains
+# reachable via --help since Typer still special-cases that flag.
 app = typer.Typer(
-    name="odot", help="A minimalist CLI task manager.", no_args_is_help=True
+    name="odot",
+    help="A minimalist CLI task manager.",
+    invoke_without_command=True,
 )
 console = Console()
 
@@ -54,7 +77,50 @@ def version_callback(value: bool) -> None:
         raise typer.Exit
 
 
-@app.callback()
+def print_summary_footer(tasks: list[Task], *, category: str | None = None) -> None:
+    """Print a dim counts line beneath a task table (#55).
+
+    The pending/done breakdown already reflects any active --done/--todo
+    filter (one side will simply be zero), so only the category needs to be
+    echoed explicitly for context.
+
+    Args:
+        tasks: The (already filtered) tasks being displayed.
+        category: The active --category filter, if any, echoed for context.
+    """
+    done_count = sum(1 for t in tasks if t.is_done)
+    pending_count = len(tasks) - done_count
+
+    category_suffix = f' in "{category}"' if category is not None else ""
+    console.print(
+        f"[dim]{len(tasks)} tasks{category_suffix} "
+        f"({pending_count} pending, {done_count} done)[/dim]"
+    )
+
+
+def print_empty_state(db: Session, *, category: str | None, done: bool | None) -> None:
+    """Print a helpful empty-state message for `list` (#58).
+
+    Distinguishes a genuinely empty database (onboarding message) from a
+    filter that simply matched nothing (message names the filter and
+    reports the true total so the user knows the data is still there). This
+    function is only called when the filtered result set is empty, so if the
+    unfiltered total is also 0, at least one filter must be active — the
+    filtered/onboarding branches are mutually exhaustive by construction.
+    """
+    total = len(core.list_tasks(db=db))
+    if total == 0:
+        console.print('No tasks yet. Add one with:  odot add "Your first task"')
+        return
+
+    status_word = f"{'completed' if done else 'pending'} " if done is not None else ""
+    category_suffix = f' in "{category}"' if category is not None else ""
+    console.print(
+        f"No {status_word}tasks found{category_suffix}. ({total} total tasks)"
+    )
+
+
+@app.callback(invoke_without_command=True)
 def main_callback(
     ctx: typer.Context,
     version: Annotated[  # noqa: ARG001  # eager option triggers version_callback
@@ -78,6 +144,11 @@ def main_callback(
         ctx.obj = session
         ctx.call_on_close(session.close)
 
+    # Bare `odot` (#61): show the task list, the most common intent, rather
+    # than help. `--help` is unaffected since Typer intercepts it earlier.
+    if ctx.invoked_subcommand is None:
+        ctx.invoke(list_tasks, ctx=ctx)
+
 
 @app.command()
 def add(
@@ -97,7 +168,11 @@ def add(
     db = ctx.obj
     task_data = TaskCreate(content=content, priority=priority, category=category)
     task = core.add_task(db=db, task_data=task_data)
-    console.print(f"[green]Added task {task.id}: {task.content}[/green]")
+    console.print(f'[green]✅ Added task {task.id}: "{task.content}"[/green]')
+    console.print(
+        f"[dim]   Priority: {task.priority} │ Category: {task.category} "
+        f"│ Created: just now[/dim]"
+    )
 
 
 @app.command()
@@ -123,12 +198,21 @@ def show(
     table.add_row("Category", task.category)
     table.add_row("Status", "Done" if task.is_done else "Pending")
 
+    # Relative time (#56) is appended alongside the absolute timestamp so
+    # both the precise value and the at-a-glance "how long ago" are visible.
     local_time = task.created_at.astimezone()
-    table.add_row("Created At", local_time.strftime(DATETIME_FORMAT))
+    table.add_row(
+        "Created At",
+        f"{local_time.strftime(DATETIME_FORMAT)} ({relative_time(task.created_at)})",
+    )
 
     if task.updated_at:
         local_updated = task.updated_at.astimezone()
-        table.add_row("Updated At", local_updated.strftime(DATETIME_FORMAT))
+        table.add_row(
+            "Updated At",
+            f"{local_updated.strftime(DATETIME_FORMAT)} "
+            f"({relative_time(task.updated_at)})",
+        )
 
     console.print(table)
 
@@ -143,7 +227,7 @@ def list_tasks(
         str | None, typer.Option("-c", "--category", help="Filter by category")
     ] = None,
     sort: Annotated[
-        str | None,
+        SortField | None,
         typer.Option(
             "-s",
             "--sort",
@@ -162,10 +246,6 @@ def list_tasks(
     """List tasks, optionally filtered and sorted."""
     db = ctx.obj
 
-    if sort and sort.lower() not in ["priority", "date", "category", "status"]:
-        console.print(f"[bold red]Invalid sort field: {sort}[/bold red]")
-        raise typer.Exit(code=1)
-
     tasks = core.list_tasks(
         db=db,
         is_done=done,
@@ -175,23 +255,45 @@ def list_tasks(
     )
 
     if not tasks:
-        console.print("No tasks found.")
+        print_empty_state(db, category=category, done=done)
         return
 
-    table = Table(title="Odot Tasks")
-    table.add_column("ID", justify="right", style="cyan", no_wrap=True)
-    table.add_column("Status", style="green")
-    table.add_column("Priority", justify="right")
-    table.add_column("Category", style="blue")
-    table.add_column("Content")
-
-    for task in tasks:
-        status_str = "[green]✓[/]" if task.is_done else "[yellow]○[/]"
-        table.add_row(
-            str(task.id), status_str, str(task.priority), task.category, task.content
-        )
-
+    table = render_task_table(tasks, title="Odot Tasks")
     console.print(table)
+    print_summary_footer(tasks, category=category)
+
+
+@app.command()
+def count(
+    ctx: typer.Context,
+    done: Annotated[
+        bool | None, typer.Option("-d/-t", "--done/--todo", help="Filter by status")
+    ] = None,
+    category: Annotated[
+        str | None, typer.Option("-c", "--category", help="Filter by category")
+    ] = None,
+) -> None:
+    """Print task counts without rendering a full table (#58)."""
+    db = ctx.obj
+    tasks = core.list_tasks(db=db, is_done=done, category=category)
+
+    # done/todo filters collapse the line to a single count since the other
+    # status is, by definition, excluded; combined with --category it reads
+    # naturally as "N completed work tasks", matching the issue's examples.
+    if done is not None:
+        status_word = "completed" if done else "pending"
+        category_prefix = f"{category} " if category else ""
+        noun = "task" if len(tasks) == 1 else "tasks"
+        console.print(f"{len(tasks)} {status_word} {category_prefix}{noun}")
+        return
+
+    done_count = sum(1 for t in tasks if t.is_done)
+    pending_count = len(tasks) - done_count
+    category_suffix = f' in "{category}"' if category else ""
+    console.print(
+        f"{len(tasks)} tasks{category_suffix} ({pending_count} pending, "
+        f"{done_count} done)"
+    )
 
 
 @app.command()
@@ -207,20 +309,75 @@ def search(
         console.print(f"No tasks matching '{phrase}' found.")
         return
 
-    table = Table(title="Search Results")
-    table.add_column("ID", justify="right", style="cyan", no_wrap=True)
-    table.add_column("Status", style="green")
-    table.add_column("Priority", justify="right")
-    table.add_column("Category", style="blue")
-    table.add_column("Content")
-
-    for task in tasks:
-        status_str = "[green]✓[/]" if task.is_done else "[yellow]○[/]"
-        table.add_row(
-            str(task.id), status_str, str(task.priority), task.category, task.content
-        )
-
+    table = render_task_table(tasks, title="Search Results", highlight=phrase)
     console.print(table)
+
+
+def _prompt_update_fields() -> dict[str, Any] | None:
+    """Interactively collect update fields via a questionary checkbox form.
+
+    Split out of `update` to keep that command's branch count under the
+    complexity gate; this owns the entire "no flags given" fallback path.
+
+    Returns:
+        A kwargs dict suitable for `TaskUpdate(**kwargs)`, which may be
+        empty if every individual field prompt was cancelled (still a valid
+        no-op update). Returns None only if the initial checkbox itself was
+        cancelled/empty, which the caller treats as a hard error.
+    """
+    choices = questionary.checkbox(
+        "Select fields to update:",
+        choices=["content", "priority", "category", "done"],
+    ).ask()
+
+    if not choices:
+        return None
+
+    update_kwargs: dict[str, Any] = {}
+    if "content" in choices:
+        update_kwargs["content"] = Prompt.ask("New content")
+    if "priority" in choices:
+        priority_str = questionary.select(
+            "New priority:", choices=["1", "2", "3"]
+        ).ask()
+        if priority_str:
+            update_kwargs["priority"] = int(priority_str)
+    if "category" in choices:
+        update_kwargs["category"] = Prompt.ask("New category")
+    if "done" in choices:
+        update_kwargs["is_done"] = questionary.confirm("Is the task done?").ask()
+
+    return update_kwargs
+
+
+def _snapshot(task: Task) -> dict[str, Any]:
+    """Copy the fields `update` diffs into a plain dict.
+
+    SQLAlchemy's identity map returns the *same* Python object for repeated
+    `get`/`update` calls on the same primary key within a session, so a
+    `before = get_task(...)` reference would be silently mutated in place by
+    the subsequent `update_task` call. Copying the plain values here is what
+    makes the before/after diff in `_print_update_diff` actually work.
+    """
+    return {
+        "content": task.content,
+        "priority": task.priority,
+        "category": task.category,
+        "is_done": task.is_done,
+    }
+
+
+def _print_update_diff(before: dict[str, Any], after: Task) -> None:
+    """Print a field-by-field diff line for each value `update` changed (#57)."""
+    for field in ("content", "priority", "category"):
+        old_value = before[field]
+        new_value = getattr(after, field)
+        if old_value != new_value:
+            console.print(f"[dim]   {field}: {old_value} → {new_value}[/dim]")
+    if before["is_done"] != after.is_done:
+        old_status = "Done" if before["is_done"] else "Pending"
+        new_status = "Done" if after.is_done else "Pending"
+        console.print(f"[dim]   status: {old_status} → {new_status}[/dim]")
 
 
 @app.command()
@@ -259,36 +416,30 @@ def update(
 
     # If no flags are provided, ask interactively via a checkbox form
     if not update_kwargs:
-        choices = questionary.checkbox(
-            "Select fields to update:",
-            choices=["content", "priority", "category", "done"],
-        ).ask()
-
-        if not choices:
+        prompted = _prompt_update_fields()
+        if prompted is None:
             console.print("[yellow]No updates provided.[/yellow]")
             raise typer.Exit(code=1)
+        update_kwargs = prompted
 
-        if "content" in choices:
-            update_kwargs["content"] = Prompt.ask("New content")
-        if "priority" in choices:
-            priority_str = questionary.select(
-                "New priority:", choices=["1", "2", "3"]
-            ).ask()
-            if priority_str:
-                update_kwargs["priority"] = int(priority_str)
-        if "category" in choices:
-            update_kwargs["category"] = Prompt.ask("New category")
-        if "done" in choices:
-            update_kwargs["is_done"] = questionary.confirm("Is the task done?").ask()
+    # Look the task up first (rather than only checking update_task's return)
+    # so we can both report not-found up front and snapshot the before-state
+    # for the diff (#57) — snapshotting the same live update_task result
+    # would be a no-op since SQLAlchemy's identity map mutates it in place.
+    existing = core.get_task(db=db, task_id=task_id)
+    if not existing:
+        console.print(f"[red]Task {task_id} not found.[/red]")
+        raise typer.Exit(code=1)
+    before = _snapshot(existing)
 
     update_data = TaskUpdate(**update_kwargs)
-
     task = core.update_task(db=db, task_id=task_id, data=update_data)
-    if not task:
+    if not task:  # pragma: no cover - existing was just confirmed present above
         console.print(f"[red]Task {task_id} not found.[/red]")
         raise typer.Exit(code=1)
 
-    console.print(f"[green]Successfully updated task {task.id}[/green]")
+    console.print(f"[green]✏️  Updated task #{task.id}[/green]")
+    _print_update_diff(before, task)
 
 
 @app.command()
@@ -306,7 +457,7 @@ def done(
     if not task:
         console.print(f"[red]Task {task_id} not found.[/red]")
         raise typer.Exit(code=1)
-    console.print(f"[green]Task {task.id} marked as done.[/green]")
+    console.print(f'[green]✅ Marked done: "{task.content}" (task #{task.id})[/green]')
 
 
 @app.command()
@@ -322,7 +473,7 @@ def undo(
     if not task:
         console.print(f"[red]Task {task_id} not found.[/red]")
         raise typer.Exit(code=1)
-    console.print(f"[green]Task {task.id} re-opened.[/green]")
+    console.print(f'[green]↩️  Re-opened: "{task.content}" (task #{task.id})[/green]')
 
 
 @app.command()
@@ -338,14 +489,26 @@ def rm(
     if task_id is None:
         task_id = prompt_task_selection(db, "remove")
 
+    # Fetched once up front and reused for both the confirmation prompt and
+    # the deletion message, so content is echoed in the destructive
+    # confirmation (#57) without a redundant second lookup.
+    task = core.get_task(db=db, task_id=task_id)
+
     if not force:
-        typer.confirm(f"Are you sure you want to delete task {task_id}?", abort=True)
-    success = core.delete_task(db=db, task_id=task_id)
-    if success:
-        console.print(f"[green]Deleted task {task_id}[/green]")
-    else:
+        prompt_label = (
+            f'Delete "{task.content}" (task #{task_id})?'
+            if task
+            else f"Delete task #{task_id}?"
+        )
+        typer.confirm(prompt_label, abort=True)
+
+    if not task or not core.delete_task(db=db, task_id=task_id):
         console.print(f"[red]Task {task_id} not found.[/red]")
         raise typer.Exit(code=1)
+
+    console.print(
+        f'[green]\U0001f5d1️  Deleted task #{task_id}: "{task.content}"[/green]'
+    )
 
 
 @app.command()
@@ -363,11 +526,13 @@ def clean(
             "Are you sure you want to delete all completed tasks?", abort=True
         )
 
-    count = core.delete_completed_tasks(db=db)
-    if count == 0:
-        console.print("[yellow]No completed tasks to delete.[/yellow]")
+    count_deleted = core.delete_completed_tasks(db=db)
+    if count_deleted == 0:
+        console.print("[yellow]⚠️  No completed tasks to delete.[/yellow]")
     else:
-        console.print(f"[green]Deleted {count} completed tasks.[/green]")
+        console.print(
+            f"[green]\U0001f9f9 Cleaned {count_deleted} completed tasks.[/green]"
+        )
 
 
 @app.command()
@@ -388,8 +553,10 @@ def purge(
             "Are you incredibly sure you want to purge all records?", abort=True
         )
 
-    count = core.delete_all_tasks(db=db)
-    console.print(f"[green]Purged {count} tasks from the database.[/green]")
+    count_deleted = core.delete_all_tasks(db=db)
+    console.print(
+        f"[green]\U0001f9f9 Purged {count_deleted} tasks from the database.[/green]"
+    )
 
 
 @app.command(name="export")
@@ -411,11 +578,11 @@ def export_cmd(
     """Export tasks to a JSON file."""
     db = ctx.obj
 
-    count = core.export_tasks(
+    count_exported = core.export_tasks(
         db=db, path=path, is_done=done, category=category, pretty=pretty
     )
     if path:
-        console.print(f"[green]Successfully exported {count} tasks to {path}[/green]")
+        console.print(f"[green]✅ Exported {count_exported} tasks to {path}[/green]")
 
 
 @app.command(name="import")
@@ -442,8 +609,8 @@ def import_cmd(
         )
 
     try:
-        count = core.import_tasks(db=db, path=path, clear=clear)
-        console.print(f"[green]Successfully imported {count} tasks from {path}[/green]")
+        count_imported = core.import_tasks(db=db, path=path, clear=clear)
+        console.print(f"[green]✅ Imported {count_imported} tasks from {path}[/green]")
     except (OSError, json.JSONDecodeError, KeyError, ValueError) as e:
         console.print(f"[bold red]Failed to import tasks: {e}[/bold red]")
         raise typer.Exit(code=1) from e
@@ -460,7 +627,7 @@ def report_cmd(
         str | None, typer.Option("-c", "--category", help="Filter by category")
     ] = None,
     sort: Annotated[
-        str | None,
+        SortField | None,
         typer.Option(
             "-s",
             "--sort",
@@ -474,10 +641,6 @@ def report_cmd(
 ) -> None:
     """Generate a Markdown or HTML report of tasks."""
     db = ctx.obj
-
-    if sort and sort.lower() not in ["priority", "date", "category", "status"]:
-        console.print(f"[bold red]Invalid sort field: {sort}[/bold red]")
-        raise typer.Exit(code=1)
 
     tasks = core.list_tasks(
         db=db, is_done=done, category=category, sort_by=sort, reverse=reverse
@@ -500,7 +663,7 @@ def report_cmd(
 
     try:
         path.write_text(content, encoding="utf-8")
-        console.print(f"[green]Successfully generated report at {path}[/green]")
+        console.print(f"[green]✅ Generated report at {path}[/green]")
     except OSError as e:
         console.print(f"[bold red]Failed to write report: {e}[/bold red]")
         raise typer.Exit(code=1) from e
@@ -510,7 +673,7 @@ def report_cmd(
 def init_db() -> None:
     """Initialize the database."""
     database.create_db_and_tables()
-    console.print("[green]Database initialized successfully.[/green]")
+    console.print("[green]✅ Database initialized successfully.[/green]")
 
 
 def main() -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -38,6 +38,9 @@ def test_main_callback_skips_init_when_session_present():
 
     class FakeContext:
         obj = "existing-session"
+        # Non-None so main_callback's bare-invocation branch (#61) is skipped;
+        # that branch is exercised separately by the bare-invocation tests.
+        invoked_subcommand = "list"
 
     ctx = FakeContext()
     main_callback(ctx)  # ty: ignore[invalid-argument-type]
@@ -215,19 +218,52 @@ def test_list_command_sort_order():
 
 
 def test_list_command_invalid_sort_field():
-    """An unrecognized --sort field is rejected."""
+    """An unrecognized --sort field is rejected at parse time by Typer (exit 2)."""
     runner.invoke(app, ["add", "Task A"])
 
     result = runner.invoke(app, ["list", "--sort", "invalid_field"])
-    assert result.exit_code == 1
-    assert "Invalid sort field" in result.stdout
+    assert result.exit_code == 2
+    assert "invalid_field" in result.output
 
 
 def test_list_command_empty(session):
-    """Test list command when no tasks exist."""
+    """An empty database shows an onboarding hint rather than a bare message (#58)."""
     result = runner.invoke(app, ["list"])
     assert result.exit_code == 0
-    assert "No tasks found" in result.stdout
+    assert "No tasks yet" in result.stdout
+    assert "odot add" in result.stdout
+
+
+def test_list_command_empty_filtered_by_category():
+    """A category filter that matches nothing names the filter and true total (#58)."""
+    runner.invoke(app, ["add", "Task A", "--category", "work"])
+
+    result = runner.invoke(app, ["list", "--category", "personal"])
+    assert result.exit_code == 0
+    assert 'No tasks found in "personal"' in result.stdout
+    assert "1 total tasks" in result.stdout
+
+
+def test_list_command_empty_filtered_by_done():
+    """A --done filter that matches nothing reports the status and true total (#58)."""
+    runner.invoke(app, ["add", "Task A"])
+
+    result = runner.invoke(app, ["list", "--done"])
+    assert result.exit_code == 0
+    assert "No completed tasks found" in result.stdout
+    assert "1 total tasks" in result.stdout
+
+
+def test_list_command_empty_filtered_by_both():
+    """Combined category and status filters both appear in the empty message (#58)."""
+    runner.invoke(app, ["add", "Task A", "--category", "work"])
+    runner.invoke(app, ["update", "1", "--done"])
+
+    # Task A is done, so filtering to pending work tasks matches nothing.
+    result = runner.invoke(app, ["list", "--category", "work", "--todo"])
+    assert result.exit_code == 0
+    assert "No pending tasks found" in result.stdout
+    assert '"work"' in result.stdout
 
 
 def test_search_command_matches_phrase():
@@ -258,7 +294,11 @@ def test_update_command_sets_explicit_fields():
         app, ["update", "1", "--content", "New Task", "--done", "--priority", "2"]
     )
     assert result.exit_code == 0
-    assert "Successfully updated task 1" in result.stdout
+    assert "Updated task #1" in result.stdout
+    # Diff lines (#57) echo the specific fields that changed.
+    assert "content: Old Task → New Task" in result.stdout
+    assert "priority: 1 → 2" in result.stdout
+    assert "status: Pending → Done" in result.stdout
 
     verify = runner.invoke(app, ["show", "1"])
     assert "New Task" in verify.stdout
@@ -271,7 +311,10 @@ def test_update_command_single_field():
 
     result = runner.invoke(app, ["update", "1", "--category", "work"])
     assert result.exit_code == 0
-    assert "Successfully updated task 1" in result.stdout
+    assert "Updated task #1" in result.stdout
+    assert "category: general → work" in result.stdout
+    # Unchanged fields should not appear in the diff.
+    assert "content:" not in result.stdout
 
 
 def test_update_command_no_fields_selected(monkeypatch):
@@ -326,7 +369,7 @@ def test_update_command_explicit_fields_skip_task_prompt(monkeypatch):
 
     result = runner.invoke(app, ["update", "--priority", "1"])
     assert result.exit_code == 0
-    assert "Successfully updated task 1" in result.stdout
+    assert "Updated task #1" in result.stdout
 
 
 def test_update_command_missing_task():
@@ -351,7 +394,8 @@ def test_update_interactive_partial_content_only(monkeypatch):
 
     result = runner.invoke(app, ["update", "1"])
     assert result.exit_code == 0
-    assert "Successfully updated task 1" in result.stdout
+    assert "Updated task #1" in result.stdout
+    assert "content: Partial task → Only content changed" in result.stdout
 
 
 def test_update_interactive_partial_cancelled_priority(monkeypatch):
@@ -373,7 +417,9 @@ def test_update_interactive_partial_cancelled_priority(monkeypatch):
 
     result = runner.invoke(app, ["update", "1"])
     assert result.exit_code == 0
-    assert "Successfully updated task 1" in result.stdout
+    assert "Updated task #1" in result.stdout
+    # Priority was never actually set, so no diff line for it appears.
+    assert "priority:" not in result.stdout
 
 
 def test_done_command():
@@ -382,7 +428,8 @@ def test_done_command():
 
     result = runner.invoke(app, ["done", "1"])
     assert result.exit_code == 0
-    assert "marked as done" in result.stdout
+    assert "Marked done" in result.stdout
+    assert "Finish me" in result.stdout
 
     verify = runner.invoke(app, ["show", "1"])
     assert "Done" in verify.stdout
@@ -402,7 +449,7 @@ def test_done_command_interactive_prompt(monkeypatch):
 
     result = runner.invoke(app, ["done"])
     assert result.exit_code == 0
-    assert "marked as done" in result.stdout
+    assert "Marked done" in result.stdout
 
 
 def test_undo_command():
@@ -412,7 +459,8 @@ def test_undo_command():
 
     result = runner.invoke(app, ["undo", "1"])
     assert result.exit_code == 0
-    assert "re-opened" in result.stdout
+    assert "Re-opened" in result.stdout
+    assert "Already done" in result.stdout
 
     verify = runner.invoke(app, ["show", "1"])
     assert "Pending" in verify.stdout
@@ -433,7 +481,7 @@ def test_undo_command_interactive_prompt(monkeypatch):
 
     result = runner.invoke(app, ["undo"])
     assert result.exit_code == 0
-    assert "re-opened" in result.stdout
+    assert "Re-opened" in result.stdout
 
 
 def test_rm_command_with_force_flag():
@@ -442,7 +490,8 @@ def test_rm_command_with_force_flag():
 
     result = runner.invoke(app, ["rm", "1", "--force"])
     assert result.exit_code == 0
-    assert "Deleted task 1" in result.stdout
+    assert "Deleted task #1" in result.stdout
+    assert "Delete me" in result.stdout
 
     verify = runner.invoke(app, ["show", "1"])
     assert verify.exit_code == 1
@@ -454,7 +503,9 @@ def test_rm_command_aborted_confirmation():
 
     result = runner.invoke(app, ["rm", "1"], input="n\n")
     assert result.exit_code == 1
-    assert "Are you sure you want to delete task 1?" in result.stdout
+    # Task content is echoed in the prompt (#57) so users confirm by what
+    # they remember, not by numeric id.
+    assert 'Delete "Delete me too" (task #1)?' in result.stdout
 
 
 def test_rm_command_interactive_prompt_confirmed(monkeypatch):
@@ -464,7 +515,7 @@ def test_rm_command_interactive_prompt_confirmed(monkeypatch):
 
     result = runner.invoke(app, ["rm"], input="y\n")
     assert result.exit_code == 0
-    assert "Deleted task 1" in result.stdout
+    assert "Deleted task #1" in result.stdout
 
 
 def test_rm_command_missing_task():
@@ -496,7 +547,7 @@ def test_clean_command_confirmed():
 
     result = runner.invoke(app, ["clean"], input="y\n")
     assert result.exit_code == 0
-    assert "Deleted 2 completed tasks." in result.stdout
+    assert "Cleaned 2 completed tasks." in result.stdout
 
     list_after = runner.invoke(app, ["list"])
     assert "Keep me 1" in list_after.stdout
@@ -552,7 +603,7 @@ def test_export_command_writes_filtered_file(tmp_path):
         app, ["export", str(export_file), "--category", "work", "--pretty"]
     )
     assert result.exit_code == 0
-    assert "Successfully exported 1 tasks" in result.stdout
+    assert "Exported 1 tasks" in result.stdout
 
     with export_file.open() as f:
         data = json.load(f)
@@ -567,7 +618,7 @@ def test_export_command_without_path_writes_to_stdout():
     result = runner.invoke(app, ["export", "--category", "work"])
     assert result.exit_code == 0
     assert "Export task 1" in result.stdout
-    assert "Successfully exported" not in result.stdout
+    assert "Exported" not in result.stdout
 
 
 def test_export_command_pretty_to_stdout():
@@ -596,7 +647,7 @@ def test_import_command_adds_tasks(tmp_path):
 
     result = runner.invoke(app, ["import", str(import_file)])
     assert result.exit_code == 0
-    assert "Successfully imported 1 tasks" in result.stdout
+    assert "Imported 1 tasks" in result.stdout
 
 
 def test_import_command_clear_aborted(tmp_path):
@@ -622,7 +673,7 @@ def test_import_command_clear_confirmed(tmp_path):
 
     result = runner.invoke(app, ["import", str(import_file), "--clear"], input="y\n")
     assert result.exit_code == 0
-    assert "Successfully imported 1 tasks" in result.stdout
+    assert "Imported 1 tasks" in result.stdout
 
     lists = runner.invoke(app, ["list"])
     assert "CLI Import Task" in lists.stdout
@@ -659,7 +710,7 @@ def test_report_command_markdown(seeded_report_tasks, tmp_path):
 
     result = runner.invoke(app, ["report", str(md_file)])
     assert result.exit_code == 0
-    assert "Successfully generated report" in result.stdout
+    assert "Generated report" in result.stdout
     assert md_file.exists()
 
     md_content = md_file.read_text()
@@ -705,13 +756,13 @@ def test_report_command_empty(session, tmp_path):
 
 
 def test_report_command_invalid_sort(tmp_path):
-    """An unrecognized --sort field is rejected."""
+    """An unrecognized --sort field is rejected at parse time by Typer (exit 2)."""
     runner.invoke(app, ["add", "Valid Task"])
     md_file = tmp_path / "report.md"
 
     result = runner.invoke(app, ["report", str(md_file), "--sort", "invalid"])
-    assert result.exit_code == 1
-    assert "Invalid sort field" in result.stdout
+    assert result.exit_code == 2
+    assert "invalid" in result.output
 
 
 def test_report_command_write_failure(tmp_path):
@@ -767,3 +818,256 @@ def test_auto_initializes_database(monkeypatch, tmp_path):
     assert result.exit_code == 0
     assert initialized, "create_db_and_tables should have been called"
     assert "Database initialized" in result.stdout
+
+
+# --------------------------------------------------------------------------- #
+# SortField / core.VALID_SORT_FIELDS parity (#61 refactor prerequisite)
+# --------------------------------------------------------------------------- #
+
+
+def test_sort_field_enum_matches_core_valid_sort_fields():
+    """SortField values must stay in sync with core.VALID_SORT_FIELDS."""
+    from odot import core
+    from odot.cli import SortField
+
+    assert {f.value for f in SortField} == set(core.VALID_SORT_FIELDS)
+
+
+# --------------------------------------------------------------------------- #
+# #54: priority indicators
+# --------------------------------------------------------------------------- #
+
+
+def test_list_command_shows_priority_dot_indicators():
+    """Priorities render as colored dot indicators, not bare numbers (#54)."""
+    runner.invoke(app, ["add", "Low priority", "-p", "1"])
+    runner.invoke(app, ["add", "Med priority", "-p", "2"])
+    runner.invoke(app, ["add", "High priority", "-p", "3"])
+
+    result = runner.invoke(app, ["list"])
+    assert result.exit_code == 0
+    assert "Low" in result.stdout
+    assert "Med" in result.stdout
+    assert "High" in result.stdout
+    assert "●" in result.stdout
+
+
+# --------------------------------------------------------------------------- #
+# #55: list summary footer
+# --------------------------------------------------------------------------- #
+
+
+def test_list_command_summary_footer_counts():
+    """The footer beneath the table reports total/pending/done counts (#55)."""
+    runner.invoke(app, ["add", "Task A"])
+    runner.invoke(app, ["add", "Task B"])
+    runner.invoke(app, ["update", "2", "--done"])
+
+    result = runner.invoke(app, ["list"])
+    assert result.exit_code == 0
+    assert "2 tasks (1 pending, 1 done)" in result.stdout
+
+
+def test_list_command_summary_footer_reflects_category_filter():
+    """The footer names the active category filter (#55)."""
+    runner.invoke(app, ["add", "Task A", "--category", "work"])
+    runner.invoke(app, ["add", "Task B", "--category", "personal"])
+
+    result = runner.invoke(app, ["list", "--category", "work"])
+    assert result.exit_code == 0
+    assert '1 tasks in "work" (1 pending, 0 done)' in result.stdout
+
+
+# --------------------------------------------------------------------------- #
+# #56: relative time in `show`
+# --------------------------------------------------------------------------- #
+
+
+def test_show_command_displays_relative_time_alongside_absolute():
+    """`show` displays a relative-time hint next to the absolute timestamp (#56)."""
+    runner.invoke(app, ["add", "Show me"])
+
+    result = runner.invoke(app, ["show", "1"])
+    assert result.exit_code == 0
+    assert "ago" in result.stdout or "just now" in result.stdout
+
+
+def test_show_command_updated_at_includes_relative_time():
+    """The Updated At row also carries a relative-time annotation (#56)."""
+    runner.invoke(app, ["add", "Show me"])
+    runner.invoke(app, ["update", "1", "-p", "3"])
+
+    result = runner.invoke(app, ["show", "1"])
+    assert result.exit_code == 0
+    assert result.stdout.count("ago") + result.stdout.count("just now") >= 2
+
+
+# --------------------------------------------------------------------------- #
+# #57: richer confirmations
+# --------------------------------------------------------------------------- #
+
+
+def test_add_command_confirmation_includes_full_context():
+    """Add's confirmation echoes priority/category so users skip a follow-up show."""
+    result = runner.invoke(
+        app, ["add", "Buy groceries", "--priority", "2", "--category", "work"]
+    )
+    assert result.exit_code == 0
+    assert "Buy groceries" in result.stdout
+    assert "Priority: 2" in result.stdout
+    assert "Category: work" in result.stdout
+
+
+def test_clean_command_no_completed_tasks_uses_warning_style():
+    """The 'nothing to clean' message is a yellow warning, not a plain notice."""
+    runner.invoke(app, ["add", "Keep me 1"])
+
+    result = runner.invoke(app, ["clean", "--force"])
+    assert result.exit_code == 0
+    assert "No completed tasks to delete." in result.stdout
+
+
+# --------------------------------------------------------------------------- #
+# #58: count command + empty states
+# --------------------------------------------------------------------------- #
+
+
+def test_count_command_all_tasks():
+    """`odot count` with no filters reports total/pending/done."""
+    runner.invoke(app, ["add", "Task A"])
+    runner.invoke(app, ["add", "Task B"])
+    runner.invoke(app, ["update", "2", "--done"])
+
+    result = runner.invoke(app, ["count"])
+    assert result.exit_code == 0
+    assert "2 tasks (1 pending, 1 done)" in result.stdout
+
+
+def test_count_command_todo_filter():
+    """`odot count --todo` collapses to a single pending count."""
+    runner.invoke(app, ["add", "Task A"])
+    runner.invoke(app, ["add", "Task B"])
+    runner.invoke(app, ["update", "2", "--done"])
+
+    result = runner.invoke(app, ["count", "--todo"])
+    assert result.exit_code == 0
+    assert "1 pending task" in result.stdout
+
+
+def test_count_command_done_and_category_filter():
+    """`odot count --done --category work` reads as 'N completed work task(s)'."""
+    runner.invoke(app, ["add", "Task A", "--category", "work"])
+    runner.invoke(app, ["add", "Task B", "--category", "work"])
+    runner.invoke(app, ["update", "1", "--done"])
+
+    result = runner.invoke(app, ["count", "--done", "--category", "work"])
+    assert result.exit_code == 0
+    assert "1 completed work task" in result.stdout
+
+
+def test_count_command_todo_filter_plural():
+    """`odot count --todo` pluralizes 'tasks' when the count isn't 1."""
+    runner.invoke(app, ["add", "Task A"])
+    runner.invoke(app, ["add", "Task B"])
+    runner.invoke(app, ["add", "Task C"])
+    runner.invoke(app, ["update", "3", "--done"])
+
+    result = runner.invoke(app, ["count", "--todo"])
+    assert result.exit_code == 0
+    assert "2 pending tasks" in result.stdout
+
+
+def test_count_command_empty_database():
+    """Counting an empty database reports zero without erroring."""
+    result = runner.invoke(app, ["count"])
+    assert result.exit_code == 0
+    assert "0 tasks (0 pending, 0 done)" in result.stdout
+
+
+def test_count_command_with_category_no_status_filter():
+    """`odot count --category work` reports the pending/done breakdown for work."""
+    runner.invoke(app, ["add", "Task A", "--category", "work"])
+
+    result = runner.invoke(app, ["count", "--category", "work"])
+    assert result.exit_code == 0
+    assert '1 tasks in "work" (1 pending, 0 done)' in result.stdout
+
+
+# --------------------------------------------------------------------------- #
+# #60: search highlight
+# --------------------------------------------------------------------------- #
+
+
+def test_search_command_highlights_match():
+    """Search results highlight the matched phrase using rich styling (#60)."""
+    runner.invoke(app, ["add", "Buy groceries for dinner"])
+
+    result = runner.invoke(app, ["search", "groceries"])
+    assert result.exit_code == 0
+    assert "groceries" in result.stdout
+
+
+def test_search_command_is_case_insensitive():
+    """Search matches regardless of case, per core's icontains-based lookup."""
+    runner.invoke(app, ["add", "Buy Groceries for dinner"])
+
+    result = runner.invoke(app, ["search", "groceries"])
+    assert result.exit_code == 0
+    assert "Groceries" in result.stdout
+
+
+def test_search_command_content_with_brackets_not_broken_by_markup():
+    """Content containing literal brackets renders safely (rich Text, not markup)."""
+    runner.invoke(app, ["add", "Buy [urgent] milk"])
+
+    result = runner.invoke(app, ["search", "milk"])
+    assert result.exit_code == 0
+    assert "[urgent]" in result.stdout
+
+
+# --------------------------------------------------------------------------- #
+# #61: bare invocation shows the task list
+# --------------------------------------------------------------------------- #
+
+
+def test_bare_invocation_shows_list_with_tasks():
+    """Running `odot` with no subcommand shows the task list (#61)."""
+    runner.invoke(app, ["add", "Task A"])
+
+    result = runner.invoke(app, [])
+    assert result.exit_code == 0
+    assert "Task A" in result.stdout
+    assert "Odot Tasks" in result.stdout
+
+
+def test_bare_invocation_shows_onboarding_on_empty_db(session):
+    """Running `odot` against an empty database shows the onboarding hint (#61)."""
+    result = runner.invoke(app, [])
+    assert result.exit_code == 0
+    assert "No tasks yet" in result.stdout
+
+
+def test_bare_invocation_still_initializes_session_lifecycle(tmp_path, monkeypatch):
+    """Bare invocation still auto-inits the DB and closes the session on exit."""
+    non_existent = tmp_path / "bare_db.sqlite"
+    monkeypatch.setattr("odot.database.get_db_path", lambda: non_existent)
+
+    result = runner.invoke(app, [])
+    assert result.exit_code == 0
+    assert "Database initialized" in result.stdout
+
+
+def test_help_still_works_with_invoke_without_command():
+    """`--help` continues to short-circuit to the help page (#61)."""
+    result = runner.invoke(app, ["--help"])
+    assert result.exit_code == 0
+    assert "A minimalist CLI task manager." in result.stdout
+
+
+def test_explicit_subcommand_does_not_trigger_bare_list():
+    """Invoking a real subcommand does not also print the bare-invocation list."""
+    runner.invoke(app, ["add", "Task A"])
+
+    result = runner.invoke(app, ["show", "1"])
+    assert result.exit_code == 0
+    assert "Odot Tasks" not in result.stdout

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -1,0 +1,153 @@
+"""Unit tests for presentation helpers in `odot._format`."""
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from rich.text import Text
+
+from odot._format import (
+    highlight_match,
+    priority_display,
+    relative_time,
+    render_task_table,
+)
+from odot.models import Task
+
+
+def make_task(**overrides: Any) -> Task:
+    """Build a Task with sensible defaults, overridable per test."""
+    defaults: dict[str, Any] = {
+        "id": 1,
+        "content": "Sample task",
+        "priority": 1,
+        "category": "general",
+        "is_done": False,
+    }
+    defaults.update(overrides)
+    return Task(**defaults)
+
+
+class TestPriorityDisplay:
+    def test_priority_1_is_low(self):
+        assert "Low" in priority_display(1)
+        assert "●" in priority_display(1)
+
+    def test_priority_2_is_med(self):
+        assert "Med" in priority_display(2)
+        assert priority_display(2).count("●") == 2
+
+    def test_priority_3_is_high(self):
+        assert "High" in priority_display(3)
+        assert priority_display(3).count("●") == 3
+
+    def test_unknown_priority_falls_back_to_number(self):
+        # Guards against malformed/legacy data crashing rendering (#54).
+        assert priority_display(0) == "0"
+
+
+class TestHighlightMatch:
+    def test_highlights_case_insensitive_match(self):
+        text = highlight_match("Buy Groceries for dinner", "groceries")
+        assert isinstance(text, Text)
+        spans = text.spans
+        assert len(spans) == 1
+        assert spans[0].style == "bold yellow"
+        # The match location covers "Groceries" (case preserved in plain text).
+        assert str(text) == "Buy Groceries for dinner"
+
+    def test_highlights_multiple_occurrences(self):
+        text = highlight_match("cat cat cat", "cat")
+        assert len(text.spans) == 3
+
+    def test_empty_phrase_returns_plain_text_no_highlight(self):
+        text = highlight_match("Some content", "")
+        assert str(text) == "Some content"
+        assert text.spans == []
+
+    def test_content_with_markup_characters_is_not_interpreted(self):
+        # Using the Text API (not f-string markup) means literal brackets in
+        # content must render literally instead of being swallowed as markup.
+        text = highlight_match("Buy [milk] and eggs", "milk")
+        assert str(text) == "Buy [milk] and eggs"
+        assert len(text.spans) == 1
+
+
+class TestRenderTaskTable:
+    def test_builds_table_with_expected_columns(self):
+        tasks = [make_task(id=1, content="Task A")]
+        table = render_task_table(tasks, title="My Title")
+        assert table.title == "My Title"
+        column_headers = [str(c.header) for c in table.columns]
+        assert column_headers == ["ID", "Status", "Priority", "Category", "Content"]
+        assert table.row_count == 1
+
+    def test_done_task_renders_check_status(self):
+        tasks = [make_task(is_done=True)]
+        table = render_task_table(tasks, title="T")
+        # Row content is stored per-column; status column is index 1.
+        status_cell = str(table.columns[1]._cells[0])
+        assert "✓" in status_cell
+
+    def test_highlight_wraps_content_in_text_object(self):
+        tasks = [make_task(content="Buy groceries")]
+        table = render_task_table(tasks, title="Search", highlight="groceries")
+        content_cell = table.columns[4]._cells[0]
+        assert isinstance(content_cell, Text)
+
+    def test_no_highlight_keeps_plain_string_content(self):
+        tasks = [make_task(content="Buy groceries")]
+        table = render_task_table(tasks, title="List")
+        content_cell = table.columns[4]._cells[0]
+        assert content_cell == "Buy groceries"
+
+
+class TestRelativeTime:
+    def test_just_now_under_one_minute(self):
+        now = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+        dt = now - timedelta(seconds=30)
+        assert relative_time(dt, now=now) == "just now"
+
+    def test_minutes_ago(self):
+        now = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+        dt = now - timedelta(minutes=2)
+        assert relative_time(dt, now=now) == "2m ago"
+
+    def test_hours_ago(self):
+        now = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+        dt = now - timedelta(hours=2)
+        assert relative_time(dt, now=now) == "2h ago"
+
+    def test_days_ago(self):
+        now = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+        dt = now - timedelta(days=3)
+        assert relative_time(dt, now=now) == "3d ago"
+
+    def test_weeks_ago(self):
+        now = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+        dt = now - timedelta(days=14)
+        assert relative_time(dt, now=now) == "2w ago"
+
+    def test_boundary_exactly_one_minute_rolls_to_minutes_bucket(self):
+        now = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+        dt = now - timedelta(minutes=1)
+        assert relative_time(dt, now=now) == "1m ago"
+
+    def test_boundary_exactly_one_hour_rolls_to_hours_bucket(self):
+        now = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+        dt = now - timedelta(hours=1)
+        assert relative_time(dt, now=now) == "1h ago"
+
+    def test_boundary_exactly_one_day_rolls_to_days_bucket(self):
+        now = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+        dt = now - timedelta(days=1)
+        assert relative_time(dt, now=now) == "1d ago"
+
+    def test_boundary_exactly_seven_days_rolls_to_weeks_bucket(self):
+        now = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+        dt = now - timedelta(days=7)
+        assert relative_time(dt, now=now) == "1w ago"
+
+    def test_defaults_now_to_current_time_when_omitted(self):
+        # No `now` passed: dt is "just now" relative to the real clock.
+        dt = datetime.now(UTC)
+        assert relative_time(dt) == "just now"


### PR DESCRIPTION
## Summary

CLI presentation refactor plus a batch of small UX features, closing seven issues.

Closes #54 — priorities now render as colored dot indicators (`● Low` / `●● Med` / `●●● High`) instead of bare numbers, in both `list` and `search`.
Closes #55 — `list` prints a dim summary footer beneath the table: total/pending/done counts, and the active category filter when set.
Closes #56 — `show` displays a relative-time hint (`2h ago`, `3d ago`, etc.) alongside each absolute timestamp (Created At / Updated At).
Closes #57 — richer, consistent confirmations across add/update/done/undo/rm/clean/purge/import/export/report: content-echoing messages, emoji-prefixed style, and `update` now prints a before/after diff of only the fields that changed; `rm`'s confirmation shows task content instead of a bare id.
Closes #58 — new `odot count` command (`--done`/`--todo`/`--category` filters, same as `list`); empty-list messaging now distinguishes a genuinely empty database (onboarding hint: `odot add "..."`) from a filter that matched nothing (names the filter, shows the true total).
Closes #60 — search results highlight the matched phrase using rich's `Text` API (not f-string markup interpolation), so content containing literal `[...]` can't be misinterpreted as markup; matching is case-insensitive, consistent with core's `icontains`-based search.
Closes #61 — bare `odot` (no subcommand) now shows the task list instead of help, via `invoke_without_command=True` + `ctx.invoke(list_tasks, ctx=ctx)` in `main_callback`. `odot --help` and `odot --version` are unaffected.

### Refactors backing the above

- **`render_task_table`** (new `src/odot/_format.py`): `list` and `search` previously built near-identical rich `Table`s inline; both now call one shared builder, with `search` passing a `highlight` phrase.
- **`SortField` (StrEnum)**: replaces the duplicated `if sort and sort.lower() not in [...]` checks in `list` and `report` with a Typer-native enum option. Invalid `--sort` values are now rejected at parse time (Typer usage error, **exit code 2**) instead of via a hand-rolled check (previously exit code 1). A test (`test_sort_field_enum_matches_core_valid_sort_fields`) asserts the enum's values stay in sync with `core.VALID_SORT_FIELDS`.

### Deviations from the issues

- `count`'s phrasing for combined `--done --category` follows the issue's exact example (`1 completed work task`, singular/plural aware) rather than a more generic `"N {category} {status} tasks"` form.
- `rm`'s confirmation prompt text changed from `Are you sure you want to delete task N?` to `Delete "content" (task #N)?` per #57's explicit request — this changes an existing test assertion, updated accordingly.
- The old CLI-side sort validation error (`Invalid sort field: ...`, exit 1) is gone; invalid `--sort` now surfaces as Typer's own usage error at exit 2. Existing tests asserting the old message/exit code were updated to match.

## Test plan

- [x] `just check` (ruff format/lint, `ty check`, pytest with 100% branch coverage gate) — all green.
- [x] `uv run pre-commit run --all-files` — clean.
- [x] Manual smoke against a throwaway `ODOT_DB_PATH`: bare `odot` (empty + populated), `odot add "test" -p 3`, `odot list`, `odot count`, `odot count --todo`, `odot search test` (confirmed ANSI highlight codes present), `odot show 1` (relative time shown), `odot list --sort bogus` (exit 2, Typer usage error), `odot list --sort priority` (works), `odot done`/`update`/`rm` (richer confirmations, diff lines).
- [x] New tests: `tests/test_format.py` (pure unit tests for `relative_time`, `priority_display`, `highlight_match`, `render_task_table`), plus CLI-level tests in `tests/test_cli.py` for `count`, bare invocation (with/without tasks, `--help` unaffected), priority dots, summary footer, richer confirmations, search highlighting, and the SortField/core sync check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YYUNdJDjHY9GAktZ3QccD5