### PR TITLE
feat: global --json output for scripting

### DIFF
--- a/src/odot/cli.py
+++ b/src/odot/cli.py
@@ -2,6 +2,7 @@
 
 import importlib.metadata
 import json
+from dataclasses import dataclass
 from enum import StrEnum
 from pathlib import Path
 from typing import Annotated, Any
@@ -18,6 +19,19 @@ from odot._format import relative_time, render_task_table
 from odot.models import Task, TaskCreate, TaskUpdate
 
 DATETIME_FORMAT = "%Y-%m-%d %H:%M:%S"
+
+
+@dataclass
+class AppContext:
+    """Per-invocation state stored on `ctx.obj`.
+
+    Holds the shared database session plus whether the global (or per-command)
+    `--json` flag was set, so every command can consult one place to decide
+    between Rich output and machine-readable JSON.
+    """
+
+    session: Session
+    json_output: bool = False
 
 
 class SortField(StrEnum):
@@ -44,6 +58,78 @@ app = typer.Typer(
     invoke_without_command=True,
 )
 console = Console()
+#: Errors are written here so stdout stays a clean JSON channel under --json.
+err_console = Console(stderr=True)
+
+#: Reusable per-command `--json` option. The global flag on the app callback
+#: (`odot --json <cmd>`) is the primary form, but the issue's examples also
+#: show `odot list --json`, so each command accepts the flag in its own
+#: position too; the two are OR-ed together via `json_enabled`.
+JsonOption = Annotated[
+    bool,
+    typer.Option("--json", help="Output machine-readable JSON instead of a table."),
+]
+
+
+def emit_json(data: object) -> None:
+    """Print a JSON document to stdout as the sole output of a `--json` command.
+
+    Plain `print(json.dumps(...))` is used rather than `console.print_json` so
+    the output is never soft-wrapped or styled: the result is a single valid
+    JSON document safe to pipe into `jq` or `python -m json.tool`.
+
+    Args:
+        data: Any JSON-serializable value (a list of task dicts, a single task
+            dict, or a small summary dict).
+    """
+    print(json.dumps(data))
+
+
+def json_enabled(ctx: typer.Context, local: bool) -> bool:
+    """Return whether JSON output is active for the current command.
+
+    True if either the global callback flag (`odot --json ...`) or the
+    command's own `--json` flag (`odot ... --json`) was given.
+    """
+    return bool(getattr(ctx.obj, "json_output", False)) or local
+
+
+def json_error(message: str, *, code: int = 1) -> typer.Exit:
+    """Print an error to stderr and return an `Exit` to raise.
+
+    Keeps stdout a clean JSON channel: under --json all diagnostics go to
+    stderr. Returned (not raised) so callers keep an explicit `raise`.
+    """
+    err_console.print(f"[red]{message}[/red]")
+    return typer.Exit(code=code)
+
+
+def require_task_id(
+    ctx: typer.Context, task_id: int | None, action: str, *, as_json: bool
+) -> int:
+    """Resolve a task id, prompting interactively unless JSON mode is active.
+
+    Under --json there is no TTY to prompt on, so a missing id is a usage
+    error (exit 2) written to stderr instead of an interactive selection.
+    """
+    if task_id is not None:
+        return task_id
+    if as_json:
+        raise json_error("A task id is required in --json mode.", code=2)
+    return prompt_task_selection(ctx.obj.session, action)
+
+
+def require_force(force: bool, prompt: str, *, as_json: bool) -> None:
+    """Confirm a destructive action, requiring --force in JSON mode.
+
+    Interactive confirmations cannot run under --json (no TTY), so --force is
+    mandatory there; without it, a usage error (exit 2) is emitted to stderr.
+    """
+    if force:
+        return
+    if as_json:
+        raise json_error("--force is required in --json mode.", code=2)
+    typer.confirm(prompt, abort=True)
 
 
 def prompt_task_selection(db: Session, action: str) -> int:
@@ -133,15 +219,29 @@ def main_callback(
             help="Show the application's version and exit.",
         ),
     ] = None,
+    json_output: Annotated[
+        bool,
+        typer.Option(
+            "--json",
+            help=(
+                "Output machine-readable JSON. Applies to list/show/add/update/"
+                "done/undo/search/count/rm/clean/purge/import; ignored by "
+                "export/report/init-db, which produce their own artifacts."
+            ),
+        ),
+    ] = False,
 ) -> None:
     """A minimalist CLI task manager."""
     if getattr(ctx, "obj", None) is None:
         db_path = database.get_db_path()
+        # Auto-init's "Database initialized" notice would corrupt the JSON on
+        # stdout, so route it to stderr when JSON output is requested.
         if not db_path.exists():
             database.create_db_and_tables()
-            console.print(f"[dim]Database initialized at {db_path}[/dim]")
+            notice = f"[dim]Database initialized at {db_path}[/dim]"
+            (err_console if json_output else console).print(notice)
         session = Session(database.get_engine())
-        ctx.obj = session
+        ctx.obj = AppContext(session=session, json_output=json_output)
         ctx.call_on_close(session.close)
 
     # Bare `odot` (#61): show the task list, the most common intent, rather
@@ -160,14 +260,21 @@ def add(
     category: Annotated[
         str, typer.Option("-c", "--category", help="Category label")
     ] = "general",
+    json_output: JsonOption = False,
 ) -> None:
     """Add a new task."""
+    as_json = json_enabled(ctx, json_output)
     if content is None:
+        if as_json:
+            raise json_error("Task content is required in --json mode.", code=2)
         content = Prompt.ask("Task content")
 
-    db = ctx.obj
+    db = ctx.obj.session
     task_data = TaskCreate(content=content, priority=priority, category=category)
     task = core.add_task(db=db, task_data=task_data)
+    if as_json:
+        emit_json(task.model_dump(mode="json"))
+        return
     console.print(f'[green]✅ Added task {task.id}: "{task.content}"[/green]')
     console.print(
         f"[dim]   Priority: {task.priority} │ Category: {task.category} "
@@ -179,15 +286,22 @@ def add(
 def show(
     ctx: typer.Context,
     task_id: Annotated[int | None, typer.Argument(help="Task ID to show")] = None,
+    json_output: JsonOption = False,
 ) -> None:
     """Show details for a specific task."""
-    db = ctx.obj
-    if task_id is None:
-        task_id = prompt_task_selection(db, "show")
+    as_json = json_enabled(ctx, json_output)
+    db = ctx.obj.session
+    task_id = require_task_id(ctx, task_id, "show", as_json=as_json)
     task = core.get_task(db=db, task_id=task_id)
     if not task:
+        if as_json:
+            raise json_error(f"Task {task_id} not found.")
         console.print(f"[red]Task {task_id} not found.[/red]")
         raise typer.Exit(code=1)
+
+    if as_json:
+        emit_json(task.model_dump(mode="json"))
+        return
 
     table = Table(title=f"Task {task.id}")
     table.add_column("Property", style="cyan")
@@ -242,9 +356,11 @@ def list_tasks(
             help="Reverse the sort order (descending)",
         ),
     ] = False,
+    json_output: JsonOption = False,
 ) -> None:
     """List tasks, optionally filtered and sorted."""
-    db = ctx.obj
+    as_json = json_enabled(ctx, json_output)
+    db = ctx.obj.session
 
     tasks = core.list_tasks(
         db=db,
@@ -253,6 +369,10 @@ def list_tasks(
         sort_by=sort,
         reverse=reverse,
     )
+
+    if as_json:
+        emit_json([task.model_dump(mode="json") for task in tasks])
+        return
 
     if not tasks:
         print_empty_state(db, category=category, done=done)
@@ -272,10 +392,25 @@ def count(
     category: Annotated[
         str | None, typer.Option("-c", "--category", help="Filter by category")
     ] = None,
+    json_output: JsonOption = False,
 ) -> None:
     """Print task counts without rendering a full table (#58)."""
-    db = ctx.obj
+    db = ctx.obj.session
     tasks = core.list_tasks(db=db, is_done=done, category=category)
+
+    if json_enabled(ctx, json_output):
+        # Report the full total/pending/done breakdown regardless of the
+        # active filter so the JSON shape is stable for scripts; the filter is
+        # already reflected in which tasks were counted.
+        done_count = sum(1 for t in tasks if t.is_done)
+        emit_json(
+            {
+                "total": len(tasks),
+                "pending": len(tasks) - done_count,
+                "done": done_count,
+            }
+        )
+        return
 
     # done/todo filters collapse the line to a single count since the other
     # status is, by definition, excluded; combined with --category it reads
@@ -300,10 +435,15 @@ def count(
 def search(
     ctx: typer.Context,
     phrase: Annotated[str, typer.Argument(help="Phrase to search for in task content")],
+    json_output: JsonOption = False,
 ) -> None:
     """Search for tasks containing a specific phrase."""
-    db = ctx.obj
+    db = ctx.obj.session
     tasks = core.search_tasks(db=db, phrase=phrase)
+
+    if json_enabled(ctx, json_output):
+        emit_json([task.model_dump(mode="json") for task in tasks])
+        return
 
     if not tasks:
         console.print(f"No tasks matching '{phrase}' found.")
@@ -397,11 +537,12 @@ def update(
         bool | None,
         typer.Option("-d/-t", "--done/--todo", help="Update completion status"),
     ] = None,
+    json_output: JsonOption = False,
 ) -> None:
     """Update properties of an existing task."""
-    db = ctx.obj
-    if task_id is None:
-        task_id = prompt_task_selection(db, "update")
+    as_json = json_enabled(ctx, json_output)
+    db = ctx.obj.session
+    task_id = require_task_id(ctx, task_id, "update", as_json=as_json)
 
     # Collect only the arguments the user explicitly provided on the command line.
     provided_args = {
@@ -414,8 +555,13 @@ def update(
         k: v for k, v in provided_args.items() if v is not None
     }
 
-    # If no flags are provided, ask interactively via a checkbox form
+    # If no flags are provided, ask interactively via a checkbox form — but
+    # never under --json, where at least one update flag is required (exit 2).
     if not update_kwargs:
+        if as_json:
+            raise json_error(
+                "At least one field flag is required in --json mode.", code=2
+            )
         prompted = _prompt_update_fields()
         if prompted is None:
             console.print("[yellow]No updates provided.[/yellow]")
@@ -428,6 +574,8 @@ def update(
     # would be a no-op since SQLAlchemy's identity map mutates it in place.
     existing = core.get_task(db=db, task_id=task_id)
     if not existing:
+        if as_json:
+            raise json_error(f"Task {task_id} not found.")
         console.print(f"[red]Task {task_id} not found.[/red]")
         raise typer.Exit(code=1)
     before = _snapshot(existing)
@@ -437,6 +585,10 @@ def update(
     if not task:  # pragma: no cover - existing was just confirmed present above
         console.print(f"[red]Task {task_id} not found.[/red]")
         raise typer.Exit(code=1)
+
+    if as_json:
+        emit_json(task.model_dump(mode="json"))
+        return
 
     console.print(f"[green]✏️  Updated task #{task.id}[/green]")
     _print_update_diff(before, task)
@@ -448,15 +600,21 @@ def done(
     task_id: Annotated[
         int | None, typer.Argument(help="Task ID to mark as done")
     ] = None,
+    json_output: JsonOption = False,
 ) -> None:
     """Mark a task as done."""
-    db = ctx.obj
-    if task_id is None:
-        task_id = prompt_task_selection(db, "mark done")
+    as_json = json_enabled(ctx, json_output)
+    db = ctx.obj.session
+    task_id = require_task_id(ctx, task_id, "mark done", as_json=as_json)
     task = core.update_task(db=db, task_id=task_id, data=TaskUpdate(is_done=True))
     if not task:
+        if as_json:
+            raise json_error(f"Task {task_id} not found.")
         console.print(f"[red]Task {task_id} not found.[/red]")
         raise typer.Exit(code=1)
+    if as_json:
+        emit_json(task.model_dump(mode="json"))
+        return
     console.print(f'[green]✅ Marked done: "{task.content}" (task #{task.id})[/green]')
 
 
@@ -464,15 +622,21 @@ def done(
 def undo(
     ctx: typer.Context,
     task_id: Annotated[int | None, typer.Argument(help="Task ID to re-open")] = None,
+    json_output: JsonOption = False,
 ) -> None:
     """Re-open a completed task."""
-    db = ctx.obj
-    if task_id is None:
-        task_id = prompt_task_selection(db, "re-open")
+    as_json = json_enabled(ctx, json_output)
+    db = ctx.obj.session
+    task_id = require_task_id(ctx, task_id, "re-open", as_json=as_json)
     task = core.update_task(db=db, task_id=task_id, data=TaskUpdate(is_done=False))
     if not task:
+        if as_json:
+            raise json_error(f"Task {task_id} not found.")
         console.print(f"[red]Task {task_id} not found.[/red]")
         raise typer.Exit(code=1)
+    if as_json:
+        emit_json(task.model_dump(mode="json"))
+        return
     console.print(f'[green]↩️  Re-opened: "{task.content}" (task #{task.id})[/green]')
 
 
@@ -483,28 +647,34 @@ def rm(
     force: Annotated[
         bool, typer.Option("-f", "--force", help="Force deletion without confirmation")
     ] = False,
+    json_output: JsonOption = False,
 ) -> None:
     """Remove a task."""
-    db = ctx.obj
-    if task_id is None:
-        task_id = prompt_task_selection(db, "remove")
+    as_json = json_enabled(ctx, json_output)
+    db = ctx.obj.session
+    task_id = require_task_id(ctx, task_id, "remove", as_json=as_json)
 
     # Fetched once up front and reused for both the confirmation prompt and
     # the deletion message, so content is echoed in the destructive
     # confirmation (#57) without a redundant second lookup.
     task = core.get_task(db=db, task_id=task_id)
 
-    if not force:
-        prompt_label = (
-            f'Delete "{task.content}" (task #{task_id})?'
-            if task
-            else f"Delete task #{task_id}?"
-        )
-        typer.confirm(prompt_label, abort=True)
+    prompt_label = (
+        f'Delete "{task.content}" (task #{task_id})?'
+        if task
+        else f"Delete task #{task_id}?"
+    )
+    require_force(force, prompt_label, as_json=as_json)
 
     if not task or not core.delete_task(db=db, task_id=task_id):
+        if as_json:
+            raise json_error(f"Task {task_id} not found.")
         console.print(f"[red]Task {task_id} not found.[/red]")
         raise typer.Exit(code=1)
+
+    if as_json:
+        emit_json({"deleted": 1})
+        return
 
     console.print(
         f'[green]\U0001f5d1️  Deleted task #{task_id}: "{task.content}"[/green]'
@@ -517,16 +687,22 @@ def clean(
     force: Annotated[
         bool, typer.Option("-f", "--force", help="Force deletion without confirmation")
     ] = False,
+    json_output: JsonOption = False,
 ) -> None:
     """Delete all completed tasks from the database."""
-    db = ctx.obj
+    as_json = json_enabled(ctx, json_output)
+    db = ctx.obj.session
 
-    if not force:
-        typer.confirm(
-            "Are you sure you want to delete all completed tasks?", abort=True
-        )
+    require_force(
+        force,
+        "Are you sure you want to delete all completed tasks?",
+        as_json=as_json,
+    )
 
     count_deleted = core.delete_completed_tasks(db=db)
+    if as_json:
+        emit_json({"deleted": count_deleted})
+        return
     if count_deleted == 0:
         console.print("[yellow]⚠️  No completed tasks to delete.[/yellow]")
     else:
@@ -541,19 +717,26 @@ def purge(
     force: Annotated[
         bool, typer.Option("-f", "--force", help="Force deletion without confirmation")
     ] = False,
+    json_output: JsonOption = False,
 ) -> None:
     """Delete all tasks, completely resetting the database."""
-    db = ctx.obj
+    as_json = json_enabled(ctx, json_output)
+    db = ctx.obj.session
 
-    if not force:
+    if not force and not as_json:
         console.print(
             "[bold red]WARNING: This will permanently delete ALL tasks.[/bold red]"
         )
-        typer.confirm(
-            "Are you incredibly sure you want to purge all records?", abort=True
-        )
+    require_force(
+        force,
+        "Are you incredibly sure you want to purge all records?",
+        as_json=as_json,
+    )
 
     count_deleted = core.delete_all_tasks(db=db)
+    if as_json:
+        emit_json({"deleted": count_deleted})
+        return
     console.print(
         f"[green]\U0001f9f9 Purged {count_deleted} tasks from the database.[/green]"
     )
@@ -575,8 +758,12 @@ def export_cmd(
         bool, typer.Option("-p", "--pretty", help="Pretty print JSON output")
     ] = False,
 ) -> None:
-    """Export tasks to a JSON file."""
-    db = ctx.obj
+    """Export tasks to a JSON file.
+
+    A global `--json` flag is accepted but ignored here: `export` already
+    produces JSON as its whole purpose, so it has no separate JSON mode.
+    """
+    db = ctx.obj.session
 
     count_exported = core.export_tasks(
         db=db, path=path, is_done=done, category=category, pretty=pretty
@@ -595,25 +782,38 @@ def import_cmd(
     clear: Annotated[
         bool, typer.Option("--clear", help="Purge existing database before importing")
     ] = False,
+    json_output: JsonOption = False,
 ) -> None:
     """Import tasks from a JSON file."""
-    db = ctx.obj
+    as_json = json_enabled(ctx, json_output)
+    db = ctx.obj.session
 
     if clear:
-        console.print(
-            "[bold red]WARNING: This will permanently delete ALL existing "
-            "tasks before importing.[/bold red]"
-        )
+        if not as_json:
+            console.print(
+                "[bold red]WARNING: This will permanently delete ALL existing "
+                "tasks before importing.[/bold red]"
+            )
+        # --clear's confirmation can't run under --json; require an explicit
+        # confirmation channel there, mirroring purge/clean (exit 2).
+        if as_json:
+            raise json_error("--clear cannot be confirmed in --json mode.", code=2)
         typer.confirm(
             "Are you incredibly sure you want to clear the database?", abort=True
         )
 
     try:
         count_imported = core.import_tasks(db=db, path=path, clear=clear)
-        console.print(f"[green]✅ Imported {count_imported} tasks from {path}[/green]")
     except (OSError, json.JSONDecodeError, KeyError, ValueError) as e:
+        if as_json:
+            raise json_error(f"Failed to import tasks: {e}") from e
         console.print(f"[bold red]Failed to import tasks: {e}[/bold red]")
         raise typer.Exit(code=1) from e
+
+    if as_json:
+        emit_json({"imported": count_imported})
+        return
+    console.print(f"[green]✅ Imported {count_imported} tasks from {path}[/green]")
 
 
 @app.command(name="report")
@@ -639,8 +839,12 @@ def report_cmd(
         typer.Option("-r", "--reverse", help="Reverse the sort order (descending)"),
     ] = False,
 ) -> None:
-    """Generate a Markdown or HTML report of tasks."""
-    db = ctx.obj
+    """Generate a Markdown or HTML report of tasks.
+
+    A global `--json` flag is accepted but ignored: `report` writes its own
+    Markdown/HTML artifact and has no JSON mode.
+    """
+    db = ctx.obj.session
 
     tasks = core.list_tasks(
         db=db, is_done=done, category=category, sort_by=sort, reverse=reverse

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1071,3 +1071,337 @@ def test_explicit_subcommand_does_not_trigger_bare_list():
     result = runner.invoke(app, ["show", "1"])
     assert result.exit_code == 0
     assert "Odot Tasks" not in result.stdout
+
+
+# --------------------------------------------------------------------------- #
+# --json output (#62)
+# --------------------------------------------------------------------------- #
+def _json_out(result):
+    """Parse a command's stdout as JSON, asserting stdout is the sole channel."""
+    return json.loads(result.stdout)
+
+
+def test_json_add_returns_task_object():
+    """`add --json` emits a single task object with the export schema fields."""
+    result = runner.invoke(app, ["add", "JSON task", "-p", "2", "-c", "work", "--json"])
+    assert result.exit_code == 0
+    data = _json_out(result)
+    assert data["id"] == 1
+    assert data["content"] == "JSON task"
+    assert data["priority"] == 2
+    assert data["category"] == "work"
+    assert data["is_done"] is False
+    # Schema mirrors export exactly.
+    assert set(data) == {
+        "id",
+        "content",
+        "priority",
+        "category",
+        "is_done",
+        "created_at",
+        "updated_at",
+    }
+
+
+def test_json_add_missing_content_exits_two():
+    """`add --json` with no content errors on stderr and exits 2 (never prompts)."""
+    result = runner.invoke(app, ["add", "--json"])
+    assert result.exit_code == 2
+    assert result.stdout == ""
+    assert "content is required" in result.stderr
+
+
+def test_json_global_flag_before_subcommand():
+    """The global callback flag (`odot --json add ...`) also enables JSON."""
+    result = runner.invoke(app, ["--json", "add", "Global flag task"])
+    assert result.exit_code == 0
+    assert _json_out(result)["content"] == "Global flag task"
+
+
+def test_json_list_empty_is_empty_array():
+    """`list --json` with no tasks emits an empty array, not prose."""
+    result = runner.invoke(app, ["list", "--json"])
+    assert result.exit_code == 0
+    assert _json_out(result) == []
+
+
+def test_json_list_returns_array():
+    """`list --json` returns a JSON array of every task."""
+    runner.invoke(app, ["add", "Task A"])
+    runner.invoke(app, ["add", "Task B"])
+
+    result = runner.invoke(app, ["list", "--json"])
+    assert result.exit_code == 0
+    data = _json_out(result)
+    assert [t["content"] for t in data] == ["Task A", "Task B"]
+
+
+def test_json_bare_invocation_emits_list_json():
+    """Bare `odot --json` falls through to the list command's JSON array."""
+    runner.invoke(app, ["add", "Bare task"])
+
+    result = runner.invoke(app, ["--json"])
+    assert result.exit_code == 0
+    assert [t["content"] for t in _json_out(result)] == ["Bare task"]
+
+
+def test_json_show_returns_object():
+    """`show --json` returns the single matching task object."""
+    runner.invoke(app, ["add", "Show me"])
+
+    result = runner.invoke(app, ["show", "1", "--json"])
+    assert result.exit_code == 0
+    assert _json_out(result)["content"] == "Show me"
+
+
+def test_json_show_missing_task_errors_on_stderr():
+    """`show --json` on a missing id errors to stderr with exit 1, clean stdout."""
+    result = runner.invoke(app, ["show", "999", "--json"])
+    assert result.exit_code == 1
+    assert result.stdout == ""
+    assert "Task 999 not found" in result.stderr
+
+
+def test_json_show_missing_id_exits_two():
+    """`show --json` without an id errors (no interactive prompt) and exits 2."""
+    result = runner.invoke(app, ["show", "--json"])
+    assert result.exit_code == 2
+    assert result.stdout == ""
+    assert "task id is required" in result.stderr
+
+
+def test_json_count_returns_breakdown():
+    """`count --json` returns a total/pending/done breakdown object."""
+    runner.invoke(app, ["add", "Task A"])
+    runner.invoke(app, ["add", "Task B"])
+    runner.invoke(app, ["done", "1"])
+
+    result = runner.invoke(app, ["count", "--json"])
+    assert result.exit_code == 0
+    assert _json_out(result) == {"total": 2, "pending": 1, "done": 1}
+
+
+def test_json_search_returns_array():
+    """`search --json` returns a JSON array of matching tasks."""
+    runner.invoke(app, ["add", "Findable phrase"])
+    runner.invoke(app, ["add", "Unrelated"])
+
+    result = runner.invoke(app, ["search", "Findable", "--json"])
+    assert result.exit_code == 0
+    data = _json_out(result)
+    assert [t["content"] for t in data] == ["Findable phrase"]
+
+
+def test_json_search_no_matches_is_empty_array():
+    """`search --json` with no matches emits an empty array."""
+    runner.invoke(app, ["add", "Task A"])
+
+    result = runner.invoke(app, ["search", "nomatch", "--json"])
+    assert result.exit_code == 0
+    assert _json_out(result) == []
+
+
+def test_json_update_returns_task():
+    """`update --json` returns the updated task object."""
+    runner.invoke(app, ["add", "Old"])
+
+    result = runner.invoke(app, ["update", "1", "--content", "New", "--json"])
+    assert result.exit_code == 0
+    assert _json_out(result)["content"] == "New"
+
+
+def test_json_update_no_fields_exits_two():
+    """`update --json` with no field flags errors (no prompt) and exits 2."""
+    runner.invoke(app, ["add", "Old"])
+
+    result = runner.invoke(app, ["update", "1", "--json"])
+    assert result.exit_code == 2
+    assert result.stdout == ""
+    assert "field flag is required" in result.stderr
+
+
+def test_json_update_missing_task_errors():
+    """`update --json` on a missing task errors to stderr with exit 1."""
+    result = runner.invoke(app, ["update", "999", "--done", "--json"])
+    assert result.exit_code == 1
+    assert result.stdout == ""
+    assert "Task 999 not found" in result.stderr
+
+
+def test_json_done_returns_task():
+    """`done --json` returns the completed task object."""
+    runner.invoke(app, ["add", "Finish me"])
+
+    result = runner.invoke(app, ["done", "1", "--json"])
+    assert result.exit_code == 0
+    data = _json_out(result)
+    assert data["is_done"] is True
+
+
+def test_json_done_missing_task_errors():
+    """`done --json` on a missing task errors to stderr with exit 1."""
+    result = runner.invoke(app, ["done", "999", "--json"])
+    assert result.exit_code == 1
+    assert result.stdout == ""
+    assert "Task 999 not found" in result.stderr
+
+
+def test_json_undo_returns_task():
+    """`undo --json` returns the re-opened task object."""
+    runner.invoke(app, ["add", "Done then undone"])
+    runner.invoke(app, ["done", "1"])
+
+    result = runner.invoke(app, ["undo", "1", "--json"])
+    assert result.exit_code == 0
+    assert _json_out(result)["is_done"] is False
+
+
+def test_json_undo_missing_task_errors():
+    """`undo --json` on a missing task errors to stderr with exit 1."""
+    result = runner.invoke(app, ["undo", "999", "--json"])
+    assert result.exit_code == 1
+    assert result.stdout == ""
+    assert "Task 999 not found" in result.stderr
+
+
+def test_json_rm_force_returns_deleted_count():
+    """`rm --force --json` returns a deleted-count object."""
+    runner.invoke(app, ["add", "Delete me"])
+
+    result = runner.invoke(app, ["rm", "1", "--force", "--json"])
+    assert result.exit_code == 0
+    assert _json_out(result) == {"deleted": 1}
+
+
+def test_json_rm_without_force_exits_two():
+    """`rm --json` without --force errors (no confirm prompt) and exits 2."""
+    runner.invoke(app, ["add", "Delete me"])
+
+    result = runner.invoke(app, ["rm", "1", "--json"])
+    assert result.exit_code == 2
+    assert result.stdout == ""
+    assert "--force is required" in result.stderr
+
+
+def test_json_rm_missing_id_exits_two():
+    """`rm --json` without an id errors (no prompt) and exits 2."""
+    result = runner.invoke(app, ["rm", "--json"])
+    assert result.exit_code == 2
+    assert result.stdout == ""
+    assert "task id is required" in result.stderr
+
+
+def test_json_rm_missing_task_errors():
+    """`rm --force --json` on a missing task errors to stderr with exit 1."""
+    result = runner.invoke(app, ["rm", "999", "--force", "--json"])
+    assert result.exit_code == 1
+    assert result.stdout == ""
+    assert "Task 999 not found" in result.stderr
+
+
+def test_json_clean_returns_deleted_count():
+    """`clean --force --json` returns a deleted-count object."""
+    runner.invoke(app, ["add", "Keep"])
+    runner.invoke(app, ["add", "Remove"])
+    runner.invoke(app, ["done", "2"])
+
+    result = runner.invoke(app, ["clean", "--force", "--json"])
+    assert result.exit_code == 0
+    assert _json_out(result) == {"deleted": 1}
+
+
+def test_json_clean_without_force_exits_two():
+    """`clean --json` without --force errors and exits 2."""
+    result = runner.invoke(app, ["clean", "--json"])
+    assert result.exit_code == 2
+    assert result.stdout == ""
+    assert "--force is required" in result.stderr
+
+
+def test_json_purge_returns_deleted_count():
+    """`purge --force --json` returns a deleted-count object, no warning prose."""
+    runner.invoke(app, ["add", "Task A"])
+    runner.invoke(app, ["add", "Task B"])
+
+    result = runner.invoke(app, ["purge", "--force", "--json"])
+    assert result.exit_code == 0
+    assert _json_out(result) == {"deleted": 2}
+
+
+def test_json_purge_without_force_exits_two():
+    """`purge --json` without --force errors and exits 2 with no warning on stdout."""
+    runner.invoke(app, ["add", "Task A"])
+
+    result = runner.invoke(app, ["purge", "--json"])
+    assert result.exit_code == 2
+    assert result.stdout == ""
+    assert "--force is required" in result.stderr
+
+
+def test_json_import_returns_imported_count(tmp_path):
+    """`import --json` returns an imported-count object."""
+    import_file = tmp_path / "import.json"
+    payload = [{"content": "Imported task", "priority": 1, "is_done": False}]
+    with import_file.open("w") as f:
+        json.dump(payload, f)
+
+    result = runner.invoke(app, ["import", str(import_file), "--json"])
+    assert result.exit_code == 0
+    assert _json_out(result) == {"imported": 1}
+
+
+def test_json_import_clear_exits_two(tmp_path):
+    """`import --clear --json` cannot confirm the wipe and exits 2."""
+    import_file = tmp_path / "import.json"
+    payload = [{"content": "Imported task", "priority": 1, "is_done": False}]
+    with import_file.open("w") as f:
+        json.dump(payload, f)
+
+    result = runner.invoke(app, ["import", str(import_file), "--clear", "--json"])
+    assert result.exit_code == 2
+    assert result.stdout == ""
+    assert "--clear cannot be confirmed" in result.stderr
+
+
+def test_json_import_malformed_errors_on_stderr(tmp_path):
+    """`import --json` on malformed JSON errors to stderr with exit 1."""
+    bad = tmp_path / "bad.json"
+    bad.write_text("not json")
+
+    result = runner.invoke(app, ["import", str(bad), "--json"])
+    assert result.exit_code == 1
+    assert result.stdout == ""
+    assert "Failed to import tasks" in result.stderr
+
+
+def test_json_export_flag_is_ignored(tmp_path):
+    """`export --json` is accepted but produces export's normal file artifact."""
+    runner.invoke(app, ["add", "Export me"])
+    out = tmp_path / "export.json"
+
+    result = runner.invoke(app, ["--json", "export", str(out)])
+    assert result.exit_code == 0
+    with out.open() as f:
+        assert json.load(f)[0]["content"] == "Export me"
+
+
+def test_json_report_flag_is_ignored(tmp_path):
+    """`report --json` is accepted but still writes its Markdown artifact."""
+    runner.invoke(app, ["add", "Report me"])
+    out = tmp_path / "report.md"
+
+    result = runner.invoke(app, ["--json", "report", str(out)])
+    assert result.exit_code == 0
+    assert "Report me" in out.read_text()
+
+
+def test_json_auto_init_notice_goes_to_stderr(tmp_path, monkeypatch):
+    """Under --json, the auto-init notice goes to stderr so stdout stays JSON."""
+    non_existent = tmp_path / "auto_init.sqlite"
+    monkeypatch.setattr("odot.database.get_db_path", lambda: non_existent)
+
+    result = runner.invoke(app, ["--json", "list"])
+    assert result.exit_code == 0
+    assert _json_out(result) == []
+    assert "Database initialized" in result.stderr
+    assert "Database initialized" not in result.stdout


### PR DESCRIPTION
Closes #62

Adds a global `--json` flag that switches most commands to machine-readable
JSON on stdout, unlocking Unix-pipeline workflows (`odot list --json | jq ...`).

## Flag placement

`--json` is available in **both** positions:
- Global, before the subcommand: `odot --json list` (eager flag on the app callback)
- Per-command, after the subcommand: `odot list --json` (matches the issue's examples)

The two are OR-ed together. `ctx.obj` now holds a small `AppContext`
(`session` + `json_output`) instead of the bare `Session`; every command reads
`ctx.obj.session`.

## JSON shape per command

| Command | `--json` output |
| --- | --- |
| `list`, `search` | JSON array of task objects (empty `[]` for no results) |
| `show`, `add`, `update`, `done`, `undo` | single task object |
| `count` | `{"total": N, "pending": N, "done": N}` |
| `rm`, `clean`, `purge` | `{"deleted": N}` |
| `import` | `{"imported": N}` |
| `export`, `report`, `init-db` | flag accepted but **ignored** (they emit their own artifacts) |

Each task is serialized via `task.model_dump(mode="json")`, so `list --json`
agrees field-for-field with `export` (`id`, `content`, `priority`, `category`,
`is_done`, `created_at`, `updated_at`).

## Output & prompt policy under `--json`

- **stdout carries only the JSON document.** A plain `print(json.dumps(...))`
  helper (`emit_json`) is used rather than `console.print_json` to avoid Rich
  soft-wrapping in pipes.
- **All diagnostics go to stderr** via a `Console(stderr=True)`. Not-found
  errors keep their existing exit code (1).
- **Prompts never fire under `--json`** (no TTY in a pipe):
  - Missing task id (`show`/`update`/`done`/`undo`/`rm`) -> error to stderr, **exit 2**.
  - `add` with no content -> error to stderr, **exit 2**.
  - `update` with no field flags -> error to stderr, **exit 2**.
  - `rm`/`clean`/`purge` without `--force` -> error to stderr, **exit 2** (`--force` is mandatory).
  - `import --clear` -> error to stderr, **exit 2** (the wipe cannot be confirmed).
- The auto-init "Database initialized" notice is routed to stderr under `--json`
  so it never corrupts the JSON on stdout.

## Deviations from the issue

- The issue sketched `ctx.obj.get("json_mode")` (a dict). Per the approved
  design this is a typed `AppContext` dataclass instead.
- The issue only showed the flag after the subcommand (`odot list --json`); the
  approved design also wants a global callback flag. Both placements are
  supported, so `odot --json list` and `odot list --json` are equivalent.
- The issue did not specify behavior for the write/confirm commands
  (`add`/`update`/`rm`/`clean`/`purge`/`import`) or for `export`/`report`; those
  follow the owner-approved design summarized above.

## Verification

- `just check` green: ruff format + ruff ALL + ty + **100% branch coverage**.
- `uv run pre-commit run --all-files` clean.
- Manual smoke (temp `ODOT_DB_PATH`, piped through `python -m json.tool`):
  bare `odot --json` -> `[]`; `add`/`show`/`count`/`rm --force` emit valid JSON;
  `odot --json rm` with no id -> exit 2, message on stderr, empty stdout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YYUNdJDjHY9GAktZ3QccD5