### PR TITLE
feat: richer interactive task selection

### DIFF
--- a/src/odot/_format.py
+++ b/src/odot/_format.py
@@ -21,6 +21,20 @@ _PRIORITY_DISPLAY = {
     3: "[bold red]●●● High[/bold red]",
 }
 
+#: Plain-text (no rich/ANSI markup) counterpart of `_PRIORITY_DISPLAY`, used by
+#: questionary choice labels — questionary titles are rendered verbatim and do
+#: not interpret rich markup, so the bracketed color tags would leak literally.
+_PRIORITY_DISPLAY_PLAIN = {
+    1: "● Low",
+    2: "●● Med",
+    3: "●●● High",
+}
+
+#: Max content width in an interactive-selection label before truncation; the
+#: dropped tail is replaced with a single-character ellipsis (counts toward the
+#: budget) so every content cell occupies the same column width.
+_CHOICE_CONTENT_WIDTH = 30
+
 
 def priority_display(priority: int) -> str:
     """Render a task priority as a colored dot indicator with a text label.
@@ -34,6 +48,69 @@ def priority_display(priority: int) -> str:
         outside the known 1-3 range.
     """
     return _PRIORITY_DISPLAY.get(priority, str(priority))
+
+
+def priority_display_plain(priority: int) -> str:
+    """Render a task priority as a dot indicator with a label, without markup.
+
+    The plain-text sibling of `priority_display`, for contexts (like
+    questionary choice titles) that print the string verbatim rather than
+    through Rich, where the `[color]...[/color]` tags would appear literally.
+
+    Args:
+        priority: Priority value (expected 1-3; any other int falls back to
+            its bare string form).
+
+    Returns:
+        A plain string such as "●● Med", or the bare number if out of range.
+    """
+    return _PRIORITY_DISPLAY_PLAIN.get(priority, str(priority))
+
+
+def _truncate(text: str, width: int) -> str:
+    """Truncate `text` to `width` characters, ending with "…" if shortened."""
+    if len(text) <= width:
+        return text
+    # Reserve one column for the ellipsis so the result never exceeds `width`.
+    return text[: width - 1] + "…"
+
+
+def build_task_choice_labels(tasks: list[Task]) -> list[tuple[str, int]]:
+    """Build aligned, plain-text selection labels for interactive prompts.
+
+    Produces one `(label, task_id)` pair per task with the id, status glyph,
+    truncated content, category, and priority laid out in fixed-width columns
+    so the menu lines up regardless of how the terminal renders it. The labels
+    contain no Rich/ANSI markup because questionary prints choice titles
+    verbatim (see `priority_display_plain`).
+
+    Column widths for the id and category are computed from the widest value
+    present so short lists stay compact while long ones still align. Every task
+    is assumed to have an `id` (persisted tasks always do).
+
+    Args:
+        tasks: The tasks to offer, in display order.
+
+    Returns:
+        A list of `(label, task_id)` tuples; the labels are safe to use as
+        both `questionary.Choice` titles and autocomplete keys.
+    """
+    id_width = max(len(str(t.id)) for t in tasks)
+    category_width = max(len(t.category) for t in tasks)
+
+    labels: list[tuple[str, int]] = []
+    for t in tasks:
+        assert t.id is not None  # persisted tasks always carry an id
+        glyph = "✔" if t.is_done else "○"
+        content = _truncate(t.content, _CHOICE_CONTENT_WIDTH).ljust(
+            _CHOICE_CONTENT_WIDTH
+        )
+        label = (
+            f"# {str(t.id).rjust(id_width)} │ {glyph} │ {content} │ "
+            f"{t.category.ljust(category_width)} │ {priority_display_plain(t.priority)}"
+        )
+        labels.append((label, t.id))
+    return labels
 
 
 def highlight_match(content: str, phrase: str) -> Text:

--- a/src/odot/cli.py
+++ b/src/odot/cli.py
@@ -15,10 +15,15 @@ from rich.table import Table
 from sqlmodel import Session
 
 from odot import core, database
-from odot._format import relative_time, render_task_table
+from odot._format import build_task_choice_labels, relative_time, render_task_table
 from odot.models import Task, TaskCreate, TaskUpdate
 
 DATETIME_FORMAT = "%Y-%m-%d %H:%M:%S"
+
+#: At or above this many tasks, `prompt_task_selection` swaps the scrollable
+#: `questionary.select` menu for a type-to-filter `questionary.autocomplete`
+#: prompt, which stays usable when a plain list would be too long to scan.
+AUTOCOMPLETE_THRESHOLD = 20
 
 
 @dataclass
@@ -132,27 +137,66 @@ def require_force(force: bool, prompt: str, *, as_json: bool) -> None:
     typer.confirm(prompt, abort=True)
 
 
+def _cancelled() -> typer.Exit:
+    """Print the shared cancel notice and return an `Exit` for the caller."""
+    console.print("[yellow]Operation cancelled.[/yellow]")
+    return typer.Exit()
+
+
+def _select_task(labels: list[tuple[str, int]], action: str) -> int:
+    """Pick a task via a scrollable `questionary.select` menu (small lists)."""
+    choices = [questionary.Choice(title=label, value=tid) for label, tid in labels]
+    task_id = questionary.select(
+        f"Select a task to {action}:",
+        choices=choices,
+        instruction="(arrow keys; type to filter)",
+        use_search_filter=True,
+        show_selected=True,
+    ).ask()
+    if task_id is None:
+        raise _cancelled()
+    return task_id
+
+
+def _autocomplete_task(labels: list[tuple[str, int]], action: str) -> int:
+    """Pick a task via a type-to-filter `questionary.autocomplete` (large lists).
+
+    `match_middle=True` lets a substring anywhere in the label narrow the list
+    (e.g. typing a category or a word from the content). The free-text answer
+    is validated against the known labels; an unrecognized entry is a hard
+    error (exit 1) rather than a silent miss.
+    """
+    label_to_id = dict(labels)
+    answer = questionary.autocomplete(
+        f"Select a task to {action} (type to filter):",
+        choices=[label for label, _ in labels],
+        match_middle=True,
+    ).ask()
+    if answer is None:
+        raise _cancelled()
+    if answer not in label_to_id:
+        console.print(f'[red]No task matches "{answer}".[/red]')
+        raise typer.Exit(code=1)
+    return label_to_id[answer]
+
+
 def prompt_task_selection(db: Session, action: str) -> int:
-    """Prompt the user to select a task using an interactive TUI list."""
+    """Prompt the user to select a task using an interactive TUI.
+
+    Small task lists use a scrollable `questionary.select` menu; once the
+    count reaches `AUTOCOMPLETE_THRESHOLD` it switches to a type-to-filter
+    `questionary.autocomplete` prompt so long lists stay navigable. Both
+    branches share the same aligned, plain-text labels and cancel handling.
+    """
     tasks = core.list_tasks(db=db)
     if not tasks:
         console.print("[yellow]No tasks available.[/yellow]")
         raise typer.Exit
 
-    choices = [
-        questionary.Choice(
-            title=f"ID {t.id} │ {t.content} [{'✔' if t.is_done else '○'}]", value=t.id
-        )
-        for t in tasks
-    ]
-
-    task_id = questionary.select(f"Select a task to {action}:", choices=choices).ask()
-
-    if task_id is None:
-        console.print("[yellow]Operation cancelled.[/yellow]")
-        raise typer.Exit
-
-    return task_id
+    labels = build_task_choice_labels(tasks)
+    if len(tasks) >= AUTOCOMPLETE_THRESHOLD:
+        return _autocomplete_task(labels, action)
+    return _select_task(labels, action)
 
 
 def version_callback(value: bool) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -103,6 +103,35 @@ def test_prompt_task_selection_returns_chosen_id(monkeypatch, session):
     assert prompt_task_selection(session, "select") == 1
 
 
+def test_prompt_task_selection_select_labels_include_metadata(monkeypatch, session):
+    """Below the threshold, select choices carry category + priority metadata."""
+    from odot.cli import prompt_task_selection
+
+    runner.invoke(app, ["add", "Buy groceries", "-c", "home", "-p", "3"])
+
+    captured: dict = {}
+
+    class MockSelect:
+        def ask(self):
+            return 1
+
+    def fake_select(*args, **kwargs):
+        captured["kwargs"] = kwargs
+        return MockSelect()
+
+    monkeypatch.setattr("questionary.select", fake_select)
+
+    assert prompt_task_selection(session, "update") == 1
+
+    title = captured["kwargs"]["choices"][0].title
+    assert "home" in title  # category column
+    assert "High" in title  # plain-text priority label
+    assert "●" in title  # priority dot glyph
+    # The instruction hint is surfaced so type-to-filter is discoverable.
+    assert captured["kwargs"]["instruction"] == "(arrow keys; type to filter)"
+    assert captured["kwargs"]["use_search_filter"] is True
+
+
 def test_prompt_task_selection_raises_on_cancel(monkeypatch, session):
     """Cancelling the TUI selection (ask returns None) exits."""
     import typer
@@ -116,6 +145,80 @@ def test_prompt_task_selection_raises_on_cancel(monkeypatch, session):
             return None
 
     monkeypatch.setattr("questionary.select", lambda *a, **k: MockSelectCancelled())
+
+    with pytest.raises(typer.Exit):
+        prompt_task_selection(session, "select")
+
+
+def _seed_tasks(count: int) -> None:
+    """Seed `count` tasks so the autocomplete threshold branch is exercised."""
+    for i in range(count):
+        runner.invoke(app, ["add", f"Task number {i}"])
+
+
+def test_prompt_task_selection_autocomplete_at_threshold(monkeypatch, session):
+    """At exactly AUTOCOMPLETE_THRESHOLD tasks, the autocomplete branch is used."""
+    from odot.cli import AUTOCOMPLETE_THRESHOLD, prompt_task_selection
+
+    _seed_tasks(AUTOCOMPLETE_THRESHOLD)
+
+    captured: dict = {}
+
+    class MockAutocomplete:
+        def ask(self):
+            # Echo back the label for task id 1 so the mapping resolves it.
+            return captured["kwargs"]["choices"][0]
+
+    def fake_autocomplete(*args, **kwargs):
+        captured["kwargs"] = kwargs
+        return MockAutocomplete()
+
+    # If select were (wrongly) chosen, this would raise and fail the test.
+    def boom(*args, **kwargs):
+        raise AssertionError("select should not be used at the threshold")
+
+    monkeypatch.setattr("questionary.autocomplete", fake_autocomplete)
+    monkeypatch.setattr("questionary.select", boom)
+
+    result = prompt_task_selection(session, "select")
+    assert result == 1
+    assert captured["kwargs"]["match_middle"] is True
+
+
+def test_prompt_task_selection_autocomplete_invalid_answer(monkeypatch, session):
+    """A free-text autocomplete answer that maps to no task exits with code 1."""
+    import typer
+
+    from odot.cli import AUTOCOMPLETE_THRESHOLD, prompt_task_selection
+
+    _seed_tasks(AUTOCOMPLETE_THRESHOLD)
+
+    class MockAutocomplete:
+        def ask(self):
+            return "not a real task label"
+
+    monkeypatch.setattr("questionary.autocomplete", lambda *a, **k: MockAutocomplete())
+
+    with pytest.raises(typer.Exit) as exc_info:
+        prompt_task_selection(session, "select")
+    assert exc_info.value.exit_code == 1
+
+
+def test_prompt_task_selection_autocomplete_cancel(monkeypatch, session):
+    """Cancelling the autocomplete prompt (ask returns None) exits."""
+    import typer
+
+    from odot.cli import AUTOCOMPLETE_THRESHOLD, prompt_task_selection
+
+    _seed_tasks(AUTOCOMPLETE_THRESHOLD)
+
+    class MockAutocompleteCancelled:
+        def ask(self):
+            return None
+
+    monkeypatch.setattr(
+        "questionary.autocomplete", lambda *a, **k: MockAutocompleteCancelled()
+    )
 
     with pytest.raises(typer.Exit):
         prompt_task_selection(session, "select")

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -6,8 +6,10 @@ from typing import Any
 from rich.text import Text
 
 from odot._format import (
+    build_task_choice_labels,
     highlight_match,
     priority_display,
+    priority_display_plain,
     relative_time,
     render_task_table,
 )
@@ -43,6 +45,61 @@ class TestPriorityDisplay:
     def test_unknown_priority_falls_back_to_number(self):
         # Guards against malformed/legacy data crashing rendering (#54).
         assert priority_display(0) == "0"
+
+
+class TestPriorityDisplayPlain:
+    def test_plain_labels_carry_no_markup(self):
+        # Questionary titles are printed verbatim, so no [rich] tags may leak.
+        for priority in (1, 2, 3):
+            rendered = priority_display_plain(priority)
+            assert "[" not in rendered
+            assert "●" in rendered
+
+    def test_plain_priority_labels(self):
+        assert priority_display_plain(1) == "● Low"
+        assert priority_display_plain(2) == "●● Med"
+        assert priority_display_plain(3) == "●●● High"
+
+    def test_unknown_priority_falls_back_to_number(self):
+        assert priority_display_plain(9) == "9"
+
+
+class TestBuildTaskChoiceLabels:
+    def test_label_includes_id_status_content_category_priority(self):
+        tasks = [
+            make_task(id=3, content="Buy groceries", category="home", priority=3),
+        ]
+        [(label, task_id)] = build_task_choice_labels(tasks)
+        assert task_id == 3
+        assert "# 3" in label
+        assert "○" in label  # pending glyph
+        assert "Buy groceries" in label
+        assert "home" in label
+        assert "●●● High" in label
+        assert "[" not in label  # no rich markup leaks into the title
+
+    def test_done_task_uses_check_glyph(self):
+        [(label, _)] = build_task_choice_labels([make_task(is_done=True)])
+        assert "✔" in label
+
+    def test_long_content_is_truncated_with_ellipsis(self):
+        long_content = "x" * 60
+        [(label, _)] = build_task_choice_labels([make_task(content=long_content)])
+        assert "…" in label
+        # 30-char budget: 29 characters plus the single-char ellipsis.
+        assert ("x" * 29 + "…") in label
+
+    def test_columns_align_across_rows(self):
+        tasks = [
+            make_task(id=1, category="a"),
+            make_task(id=200, category="longer-category"),
+        ]
+        labels = [label for label, _ in build_task_choice_labels(tasks)]
+        # Padding the id and category cells to a common width means every "│"
+        # separator lands at the same offset in both rows.
+        assert [i for i, c in enumerate(labels[0]) if c == "│"] == [
+            i for i, c in enumerate(labels[1]) if c == "│"
+        ]
 
 
 class TestHighlightMatch:


### PR DESCRIPTION
Closes #63

## What changed

`prompt_task_selection` (used by `show`, `update`, `done`, `undo`, `rm`) now
renders richer, aligned selection labels and scales to large task lists.

### Before / after menu labels

Before — flat, metadata-free:
```
ID 1 │ Buy groceries [○]
ID 2 │ Finish quarterly report [○]
ID 3 │ Call dentist [○]
```

After — aligned columns with status glyph, truncated content, category, and a
plain-text priority indicator:
```
# 1 │ ○ │ Buy groceries                  │ home     │ ●●● High
# 2 │ ○ │ Finish quarterly report        │ work     │ ●● Med
# 3 │ ○ │ Call dentist                   │ personal │ ● Low
```

Content is truncated to 30 characters with an ellipsis; the id and category
columns are padded to a common width so every row lines up. Labels are plain
text (no Rich markup) because questionary prints choice titles verbatim — a new
`priority_display_plain` helper provides the markup-free priority label.

### Instruction hint

`questionary.select` is called with `instruction="(arrow keys; type to filter)"`
and `use_search_filter=True`, so the built-in type-to-filter capability
(questionary 2.1.1) is discoverable.

### Threshold / autocomplete behavior

A documented module-level constant `AUTOCOMPLETE_THRESHOLD = 20` governs the
switch:

- **Below 20 tasks:** scrollable `questionary.select` menu (with search filter).
- **At or above 20 tasks:** `questionary.autocomplete` with `match_middle=True`,
  so typing any substring (a word from the content or a category) narrows the
  list. The free-text answer is validated against the known labels — an
  unrecognized entry prints a clear error and exits 1.

The cancel path (`ask()` returns `None` → "Operation cancelled." + `typer.Exit`)
is preserved in both branches, and the existing `--json` guard is untouched:
prompts are still never reached under `--json` (missing id → exit 2).

## Testing

- New unit tests for `priority_display_plain` and `build_task_choice_labels`
  (metadata present, done glyph, truncation, column alignment).
- New CLI tests: select-branch label metadata + instruction, autocomplete at
  exactly the threshold (20 tasks), autocomplete invalid-answer (exit 1), and
  cancel in both branches.
- `just check` green, 100% branch coverage, `pre-commit run --all-files` clean.
- Manual smoke against a temp `ODOT_DB_PATH` verified label alignment by
  constructing the choices list (a real TTY isn't available in this
  environment, so the interactive prompt itself was exercised via the mocked
  tests rather than a live pty).

## Deviations from the issue

- The issue's mock used `#1 │ ○ │ ...`; the implemented labels right-pad the id
  (`# 1`) so multi-digit ids stay column-aligned. Otherwise the layout matches.
- The issue suggested `instruction="(Use arrow keys, type to filter)"`; the
  wording was trimmed to `(arrow keys; type to filter)` and paired with
  `use_search_filter=True` so the hint reflects a real, enabled capability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YYUNdJDjHY9GAktZ3QccD5
