### PR TITLE
chore: release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-07-14
+
+### Added
+
+- `odot count` command with the same `--done/--todo` and `--category` filters as `list` (#58)
+- Global `--json` flag: machine-readable output for list/search/show/add/update/done/undo/count, status objects for rm/clean/purge/import; prompts are disabled under `--json` (#62)
+- Color-coded priority indicators (`● Low` / `●● Med` / `●●● High`) in task tables (#54)
+- Summary counts footer under `odot list` (#55)
+- Relative timestamps ("2h ago") alongside absolute times in `odot show` (#56)
+- Search results highlight the matched phrase (#60)
+- Running bare `odot` now shows the task list instead of help (#61)
+- Interactive task selection shows status, category, and priority, supports type-to-filter, and switches to an autocomplete prompt for 20+ tasks (#63)
+- `python -m odot` entry point
+- PEP 561 `py.typed` marker — the package now ships type information
+- Project docs: CONTRIBUTING.md, CLAUDE.md, and this changelog
+- Automated releases: merging an unpublished version to main now publishes to PyPI, tags, and drafts a GitHub release; a version-guard CI check enforces semver-correct bumps
+
+### Changed
+
+- Friendlier, more informative success and confirmation messages across all commands; `update` now shows a before/after diff (#57)
+- Invalid `--sort` values are rejected at parse time with a usage error (exit 2)
+- Search matching is now explicitly case-insensitive rather than relying on SQLite's ASCII-only default
+- Core API: `list_tasks` raises `ValueError` on invalid sort fields (#47), `export_tasks` accepts an output stream (#48), new public `set_engine()`/`reset_engine()` (#52)
+- Tooling: ruff `select=["ALL"]` with curated ignores, ty type checking, 100% branch-coverage gate
+
+### Removed
+
+- Python 3.10 support — odot now requires Python 3.11+
+
 ## [0.3.0] - 2026-05-17
 
 ### Added
@@ -69,7 +98,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Resolved a duplicate auth header that caused the bump-version workflow to
   fail.
 
-[Unreleased]: https://github.com/jkomalley/odot/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/jkomalley/odot/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/jkomalley/odot/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/jkomalley/odot/compare/v0.2.1...v0.3.0
 [0.2.1]: https://github.com/jkomalley/odot/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/jkomalley/odot/compare/v0.1.1...v0.2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "odot"
-version = "0.3.0"
+version = "0.4.0"
 description = "A minimalist, interactive command-line task manager built with Python."
 readme = "README.md"
 authors = [{ name = "Kyle O'Malley", email = "j.kyle.omalley@gmail.com" }]

--- a/uv.lock
+++ b/uv.lock
@@ -330,7 +330,7 @@ wheels = [
 
 [[package]]
 name = "odot"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "questionary" },


### PR DESCRIPTION
## Summary

This release bumps the minor version to 0.4.0 due to significant new features:

- New `odot count` command with filtering
- Global `--json` flag for scripting support
- Interactive task selection improvements
- Color-coded priority indicators
- Relative timestamps in task display
- PEP 561 type information support
- Automated release workflow

Also raises the Python floor from 3.10 to 3.11+ to align with current best practices.

Merging this PR will auto-publish v0.4.0 to PyPI, create the v0.4.0 tag, and draft the GitHub release via the CD workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YYUNdJDjHY9GAktZ3QccD5