### PR TITLE
ci: generate release notes for CD draft releases

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -60,5 +60,6 @@ jobs:
           git push origin "v${VERSION}"
           gh release create "v${VERSION}" \
             --title "v${VERSION}" \
+            --generate-notes \
             --draft \
             dist/*


### PR DESCRIPTION
Closes #105

The CD workflow's draft releases were created with an empty body (spotted on the v0.4.0 draft, whose notes I backfilled from the CHANGELOG). Adds `--generate-notes` to `gh release create` so future drafts carry the auto-generated PR summary for review before publishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YYUNdJDjHY9GAktZ3QccD5