### PR TITLE
docs: sync docs with implementation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,8 @@ The project uses a `src/odot/` layout with this module structure:
 - `models.py` — SQLModel schemas: `TaskBase` (shared fields: `content`, `priority` 1–3, `category`), `Task` (the `tasks` table, adds `id`, `is_done`, `created_at`, `updated_at`), `TaskCreate` (creation input), `TaskUpdate` (all fields optional, for partial updates).
 - `core.py` — Pure CRUD and business logic (add/get/list/search/update/delete tasks, bulk clean/purge, JSON import/export, Markdown/HTML report generation). Operates on a `Session` passed in by the caller; knows nothing about the CLI or presentation layer.
 - `database.py` — Engine, session, and path management: `get_db_path()` (honors `ODOT_DB_PATH`), `get_engine()` (lazily-created module-level singleton engine), `create_db_and_tables()`.
-- `cli.py` — Typer commands, Rich table/console output, Questionary interactive prompts (used when a required argument like a task ID is omitted).
+- `cli.py` — Typer commands, Rich console output, Questionary interactive prompts (used when a required argument like a task ID is omitted). Table and choice-label formatting is delegated to `_format.py`.
+- `_format.py` — Presentation helpers shared by the CLI: task-table rendering (`render_task_table`), priority display (`priority_display`), relative timestamps (`relative_time`), phrase highlighting (`highlight_match`), and interactive-choice labels (`build_task_choice_labels`).
 
 Key design decisions:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,8 @@ responsibility:
 | `models.py` | SQLModel schemas: `TaskBase`, `Task` (the `tasks` table), `TaskCreate`, `TaskUpdate`. |
 | `core.py` | Pure CRUD and business logic. Takes a `Session`; knows nothing about the CLI. |
 | `database.py` | Engine/session/path management, including the `ODOT_DB_PATH` override and the engine singleton. |
-| `cli.py` | Typer commands, Rich output, Questionary interactive prompts. |
+| `cli.py` | Typer commands, Rich output, Questionary interactive prompts. Delegates table/label formatting to `_format.py`. |
+| `_format.py` | Presentation helpers shared by the CLI: task-table rendering, priority display, relative time, phrase highlighting. |
 
 ## Running checks
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@
 - **Filtering & sorting** — slice your task list by status, category, priority, or date
 - **Import / export** — move tasks between machines with JSON
 - **Reports** — generate Markdown or HTML reports with one command
+- **Scripting-friendly** — machine-readable JSON output via a global `--json` flag
 - **Local first** — SQLite-backed, zero-configuration, works offline
 
 ## Installation
@@ -74,7 +75,22 @@ odot search "groceries"
 odot list --done                       # completed tasks only
 odot list -c work --todo               # open work tasks
 odot list --sort priority --reverse    # descending priority
+odot count --todo -c work              # count matches without a table
 ```
+
+### Scripting
+
+Add `--json` to emit machine-readable JSON instead of a table, ready to pipe
+into tools like [`jq`](https://jqlang.github.io/jq/):
+
+```bash
+odot list --json | jq '.[] | .content'   # list open task titles
+odot count --json                         # {"total": N, "pending": N, "done": N}
+```
+
+> `--json` applies to `list`, `show`, `add`, `update`, `done`, `undo`,
+> `search`, `count`, `rm`, `clean`, `purge`, and `import`. It is ignored by
+> `export` and `report`, which already produce their own artifacts.
 
 ### Import, Export & Reports
 

--- a/src/odot/cli.py
+++ b/src/odot/cli.py
@@ -438,7 +438,7 @@ def count(
     ] = None,
     json_output: JsonOption = False,
 ) -> None:
-    """Print task counts without rendering a full table (#58)."""
+    """Print task counts without rendering a full table."""
     db = ctx.obj.session
     tasks = core.list_tasks(db=db, is_done=done, category=category)
 


### PR DESCRIPTION
## Summary

Fixes four points where the prose docs had drifted from the shipped code. No behavior changes — docs plus one docstring. Landed as three atomic commits.

1. **`_format.py` was invisible in both module maps.** The presentation module (added by the #100/#102 refactors) holds the helpers `cli.py` imports — `render_task_table`, `build_task_choice_labels`, `relative_time`, `priority_display`, `highlight_match` — but neither CLAUDE.md's Architecture list nor CONTRIBUTING.md's Project layout table mentioned it. Both claimed 4 modules; there are 5.
2. **CLAUDE.md's `cli.py` line was stale** — table rendering moved to `_format.py`, so `cli.py` now delegates it.
3. **README omitted the `count` command and the global `--json` flag** (both 0.4.0 features). Added a Features bullet, a `count` usage example, and a Scripting section showing `--json | jq`.
4. **`count` leaked `(#58)` into `odot count --help`** via its docstring. Removed.

`init-db` stays undocumented in the README on purpose (the DB auto-initializes). No CHANGELOG entry: these document already-shipped features and change no user-facing behavior.

## Verification

- `just check` — format + lint + type + 197 tests at 100% coverage, clean.
- `uv run odot count --help` — `(#58)` gone.
- `uv run odot --help` — command list and `--json` description render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)