### PR TITLE
fix: questionary crash and validation gaps found in library-API audit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
+    "pydantic>=2.9.0",
     "questionary>=2.1.1",
     "rich>=14.3.2",
     "sqlmodel>=0.0.33",

--- a/src/odot/cli.py
+++ b/src/odot/cli.py
@@ -151,6 +151,7 @@ def _select_task(labels: list[tuple[str, int]], action: str) -> int:
         choices=choices,
         instruction="(arrow keys; type to filter)",
         use_search_filter=True,
+        use_jk_keys=False,
         show_selected=True,
     ).ask()
     if task_id is None:

--- a/src/odot/cli.py
+++ b/src/odot/cli.py
@@ -144,7 +144,12 @@ def _cancelled() -> typer.Exit:
 
 
 def _select_task(labels: list[tuple[str, int]], action: str) -> int:
-    """Pick a task via a scrollable `questionary.select` menu (small lists)."""
+    """Pick a task via a scrollable `questionary.select` menu (small lists).
+
+    Uses `use_search_filter=True` to support type-to-filter, but must set
+    `use_jk_keys=False` because questionary does not allow both simultaneously
+    (j/k can be part of the search string).
+    """
     choices = [questionary.Choice(title=label, value=tid) for label, tid in labels]
     task_id = questionary.select(
         f"Select a task to {action}:",

--- a/src/odot/cli.py
+++ b/src/odot/cli.py
@@ -9,6 +9,7 @@ from typing import Annotated, Any
 
 import questionary
 import typer
+from pydantic import ValidationError
 from rich.console import Console
 from rich.prompt import Prompt
 from rich.table import Table
@@ -320,7 +321,14 @@ def add(
         content = Prompt.ask("Task content")
 
     db = ctx.obj.session
-    task_data = TaskCreate(content=content, priority=priority, category=category)
+    try:
+        task_data = TaskCreate(content=content, priority=priority, category=category)
+    except ValidationError as e:
+        message = f"Invalid task data: {e}"
+        if as_json:
+            raise json_error(message) from e
+        console.print(f"[red]{message}[/red]")
+        raise typer.Exit(code=1) from e
     task = core.add_task(db=db, task_data=task_data)
     if as_json:
         emit_json(task.model_dump(mode="json"))
@@ -630,7 +638,14 @@ def update(
         raise typer.Exit(code=1)
     before = _snapshot(existing)
 
-    update_data = TaskUpdate(**update_kwargs)
+    try:
+        update_data = TaskUpdate(**update_kwargs)
+    except ValidationError as e:
+        message = f"Invalid task data: {e}"
+        if as_json:
+            raise json_error(message) from e
+        console.print(f"[red]{message}[/red]")
+        raise typer.Exit(code=1) from e
     task = core.update_task(db=db, task_id=task_id, data=update_data)
     if not task:  # pragma: no cover - existing was just confirmed present above
         console.print(f"[red]Task {task_id} not found.[/red]")

--- a/src/odot/core.py
+++ b/src/odot/core.py
@@ -294,7 +294,7 @@ def generate_markdown_report(tasks: list[Task]) -> str:
     # Group by category (requires sorting by category first)
     sorted_tasks = sorted(tasks, key=lambda t: t.category)
     for category, category_tasks in groupby(sorted_tasks, key=lambda t: t.category):
-        lines.append(f"## {category.title()}")
+        lines.append(f"## {category}")
         for task in category_tasks:
             checkbox = "[x]" if task.is_done else "[ ]"
             lines.append(f"- {checkbox} {task.content} (Priority: {task.priority})")
@@ -361,7 +361,7 @@ def generate_html_report(tasks: list[Task]) -> str:
     else:
         sorted_tasks = sorted(tasks, key=lambda t: t.category)
         for category, category_tasks in groupby(sorted_tasks, key=lambda t: t.category):
-            html.append(f"    <h2>{escape(category.title())}</h2>")
+            html.append(f"    <h2>{escape(category)}</h2>")
             html.append("    <ul class='task-list'>")
             for task in category_tasks:
                 status_class = "done" if task.is_done else "pending"

--- a/src/odot/models.py
+++ b/src/odot/models.py
@@ -13,6 +13,8 @@ class TaskBase(SQLModel):
     category: str = Field(
         default="general",
         index=True,
+        min_length=1,
+        max_length=255,
         description="Free-text category label; matching is case-sensitive by design.",
     )
 
@@ -34,7 +36,7 @@ class TaskUpdate(SQLModel):
     priority: int | None = Field(
         default=None, ge=1, le=3, description="Priority from 1 to 3"
     )
-    category: str | None = Field(default=None)
+    category: str | None = Field(default=None, min_length=1, max_length=255)
     is_done: bool | None = Field(default=None)
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -95,6 +95,14 @@ def test_json_add_out_of_range_priority_errors_on_stderr():
     assert "priority" in result.stderr.lower()
 
 
+def test_add_command_empty_category_is_rejected():
+    """An explicit empty --category is a clean CLI error, not a blank category."""
+    result = runner.invoke(app, ["add", "Test Task", "--category", ""])
+    assert result.exit_code == 1
+    assert "ValidationError" not in result.stdout
+    assert "category" in result.stdout.lower()
+
+
 def test_prompt_task_selection_raises_when_no_tasks(session):
     """Selecting a task with an empty task list exits instead of prompting."""
     import typer
@@ -516,6 +524,15 @@ def test_json_update_out_of_range_priority_errors_on_stderr():
     assert result.stdout == ""
     assert "ValidationError" not in result.stderr
     assert "priority" in result.stderr.lower()
+
+
+def test_update_command_empty_category_is_rejected():
+    """An explicit empty --category on update is a clean CLI error."""
+    runner.invoke(app, ["add", "Task to update"])
+    result = runner.invoke(app, ["update", "1", "--category", ""])
+    assert result.exit_code == 1
+    assert "ValidationError" not in result.stdout
+    assert "category" in result.stdout.lower()
 
 
 def test_update_interactive_partial_content_only(monkeypatch):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -871,9 +871,9 @@ def test_report_command_markdown(seeded_report_tasks, tmp_path):
 
     md_content = md_file.read_text()
     assert "# Odot Task Report" in md_content
-    assert "## Work" in md_content
+    assert "## work" in md_content
     assert "- [ ] Work task (Priority: 3)" in md_content
-    assert "## Personal" in md_content
+    assert "## personal" in md_content
     assert "- [x] Personal task (Priority: 1)" in md_content
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -78,6 +78,23 @@ def test_add_command_interactive_prompt():
     assert "Interactive task" in result.stdout
 
 
+def test_add_command_out_of_range_priority_reports_clean_error():
+    """An out-of-range --priority is a clean CLI error, not a raw traceback."""
+    result = runner.invoke(app, ["add", "Test Task", "--priority", "99"])
+    assert result.exit_code == 1
+    assert "ValidationError" not in result.stdout
+    assert "priority" in result.stdout.lower()
+
+
+def test_json_add_out_of_range_priority_errors_on_stderr():
+    """`add --json` with an invalid priority errors to stderr, not a traceback."""
+    result = runner.invoke(app, ["add", "Test Task", "--priority", "99", "--json"])
+    assert result.exit_code == 1
+    assert result.stdout == ""
+    assert "ValidationError" not in result.stderr
+    assert "priority" in result.stderr.lower()
+
+
 def test_prompt_task_selection_raises_when_no_tasks(session):
     """Selecting a task with an empty task list exits instead of prompting."""
     import typer
@@ -480,6 +497,25 @@ def test_update_command_missing_task():
     result = runner.invoke(app, ["update", "999", "--done"])
     assert result.exit_code == 1
     assert "Task 999 not found" in result.stdout
+
+
+def test_update_command_out_of_range_priority_reports_clean_error():
+    """An out-of-range --priority is a clean CLI error, not a raw traceback."""
+    runner.invoke(app, ["add", "Task to update"])
+    result = runner.invoke(app, ["update", "1", "--priority", "0"])
+    assert result.exit_code == 1
+    assert "ValidationError" not in result.stdout
+    assert "priority" in result.stdout.lower()
+
+
+def test_json_update_out_of_range_priority_errors_on_stderr():
+    """`update --json` with an invalid priority errors to stderr cleanly."""
+    runner.invoke(app, ["add", "Task to update"])
+    result = runner.invoke(app, ["update", "1", "--priority", "0", "--json"])
+    assert result.exit_code == 1
+    assert result.stdout == ""
+    assert "ValidationError" not in result.stderr
+    assert "priority" in result.stderr.lower()
 
 
 def test_update_interactive_partial_content_only(monkeypatch):

--- a/tests/test_cli_questionary_api.py
+++ b/tests/test_cli_questionary_api.py
@@ -1,0 +1,42 @@
+"""Tests that validate external library API contracts.
+
+These tests call the real libraries (not mocked) to ensure parameter
+combinations and constraints are respected. This catches issues like
+conflicting parameters before code reaches production.
+"""
+
+import pytest
+import questionary
+
+
+def test_select_task_questionary_parameters_valid():
+    """Ensure questionary.select() accepts _select_task parameter combinations.
+
+    questionary.select() cannot have both use_search_filter=True and
+    use_jk_keys=True simultaneously, as j/k can be part of the search string.
+    This test validates that our parameter choices are compatible.
+
+    Regression test for: ValueError: Cannot use j/k keys with prefix filter
+    search, since j/k can be part of the prefix.
+    """
+    # This should NOT raise ValueError
+    q = questionary.select(
+        "Select a task:",
+        choices=[questionary.Choice("Task 1", 1), questionary.Choice("Task 2", 2)],
+        instruction="(arrow keys; type to filter)",
+        use_search_filter=True,
+        use_jk_keys=False,  # Explicitly False to avoid conflict
+        show_selected=True,
+    )
+    # If we got here, the parameters are valid (questionary didn't raise)
+    assert q is not None
+
+
+def test_autocomplete_task_questionary_parameters_valid():
+    """Ensure questionary.autocomplete() parameters are valid."""
+    q = questionary.autocomplete(
+        "Select a task (type to filter):",
+        choices=["Task 1", "Task 2"],
+        match_middle=True,
+    )
+    assert q is not None

--- a/tests/test_cli_questionary_api.py
+++ b/tests/test_cli_questionary_api.py
@@ -5,7 +5,6 @@ combinations and constraints are respected. This catches issues like
 conflicting parameters before code reaches production.
 """
 
-import pytest
 import questionary
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -403,13 +403,30 @@ def test_generate_markdown_report():
     report = core.generate_markdown_report(tasks)
 
     assert "# Odot Task Report" in report
-    assert "## Personal" in report
+    assert "## personal" in report
     assert "- [x] Personal Task (Priority: 1)" in report
-    assert "## Work" in report
+    assert "## work" in report
     assert "- [ ] Work Task (Priority: 3)" in report
 
     empty_report = core.generate_markdown_report([])
     assert "No tasks found." in empty_report
+
+
+def test_generate_markdown_report_preserves_case_sensitive_categories():
+    """Distinct case-variant categories must render as distinct headers.
+
+    Categories are case-sensitive by design (see CLAUDE.md); title-casing
+    the header would make "work" and "Work" collide into identical "## Work"
+    sections with no way to tell them apart.
+    """
+    tasks = [
+        Task(content="lowercase task", priority=1, category="work", is_done=False),
+        Task(content="capitalized task", priority=1, category="Work", is_done=False),
+    ]
+    report = core.generate_markdown_report(tasks)
+
+    assert "## work" in report
+    assert "## Work" in report
 
 
 def test_generate_html_report():
@@ -422,8 +439,8 @@ def test_generate_html_report():
 
     assert "<!DOCTYPE html>" in report
     assert "<h1>Odot Task Report</h1>" in report
-    assert "<h2>Personal</h2>" in report
-    assert "<h2>Work</h2>" in report
+    assert "<h2>personal</h2>" in report
+    assert "<h2>work</h2>" in report
     assert "Personal Task" in report
     assert "Work Task" in report
     assert "class='task-item done'" in report
@@ -431,6 +448,18 @@ def test_generate_html_report():
 
     empty_report = core.generate_html_report([])
     assert "<p>No tasks found.</p>" in empty_report
+
+
+def test_generate_html_report_preserves_case_sensitive_categories():
+    """Distinct case-variant categories must render as distinct headers."""
+    tasks = [
+        Task(content="lowercase task", priority=1, category="work", is_done=False),
+        Task(content="capitalized task", priority=1, category="Work", is_done=False),
+    ]
+    report = core.generate_html_report(tasks)
+
+    assert "<h2>work</h2>" in report
+    assert "<h2>Work</h2>" in report
 
 
 def test_generate_html_report_escapes_user_content():
@@ -449,4 +478,4 @@ def test_generate_html_report_escapes_user_content():
     assert "&lt;head&gt;" in report
     assert "&amp;" in report
     assert "&quot;quotes&quot;" in report
-    assert "&lt;Script&gt;" in report
+    assert "&lt;script&gt;" in report

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -41,6 +41,12 @@ def test_task_creation_invalid_content():
         TaskCreate(content="a" * 256)  # Exceeds max length
 
 
+def test_task_creation_invalid_category():
+    """An empty category is rejected rather than silently persisted blank."""
+    with pytest.raises(ValidationError):
+        TaskCreate(content="Valid content", category="")
+
+
 def test_task_table_defaults():
     """Test default values for full Task table model."""
     task = Task(content="Database test")

--- a/uv.lock
+++ b/uv.lock
@@ -333,6 +333,7 @@ name = "odot"
 version = "0.4.0"
 source = { editable = "." }
 dependencies = [
+    { name = "pydantic" },
     { name = "questionary" },
     { name = "rich" },
     { name = "sqlmodel" },
@@ -351,6 +352,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "pydantic", specifier = ">=2.9.0" },
     { name = "questionary", specifier = ">=2.1.1" },
     { name = "rich", specifier = ">=14.3.2" },
     { name = "sqlmodel", specifier = ">=0.0.33" },


### PR DESCRIPTION
## Summary

Fixes a crash reported in interactive task selection (`odot done` with no id), plus three related bugs found while auditing external-library usage for similar issues.

- **`questionary.select()` crash** — `use_jk_keys=True` (default) conflicts with `use_search_filter=True` ("Cannot use j/k keys with prefix filter search"). This was the originally reported crash on `odot done`/`update`/`rm` when prompted interactively.
- **Uncaught `ValidationError` in `add`/`update`** — an out-of-range `--priority` (or other Pydantic validation failure) raised a raw traceback instead of a clean error. In `--json` mode this broke the documented machine-readable-stdout contract. `import` already handled this correctly; `add`/`update` didn't.
- **Empty `--category ""` silently accepted** — unlike `content`, `category` had no `min_length` constraint, so an empty category was persisted instead of being rejected.
- **Report headers collided on case-distinct categories** — `generate_markdown_report`/`generate_html_report` title-cased category headers, so `"work"` and `"Work"` (distinct by design, per project docs) rendered as identical `## Work` headers with no way to tell the sections apart.

Also added a contract-test file that calls the real `questionary` library (not mocked) to catch parameter-incompatibility regressions like the first bug — the existing test suite mocked `questionary` entirely, so it verified *what we passed* but never *whether the library accepted it*.

## Test plan

- [x] `just check` passes (format, lint, typecheck, 100% branch coverage, all 208 tests)
- [x] Manually reproduced and verified the fix for each of the four bugs via CLI invocation
- [x] New regression tests added for all four bugs (plain and `--json` modes where applicable)