### PR TITLE
chore: release v0.5.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "odot"
-version = "0.4.0"
+version = "0.5.0"
 description = "A minimalist, interactive command-line task manager built with Python."
 readme = "README.md"
 authors = [{ name = "Kyle O'Malley", email = "j.kyle.omalley@gmail.com" }]

--- a/uv.lock
+++ b/uv.lock
@@ -330,7 +330,7 @@ wheels = [
 
 [[package]]
 name = "odot"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
Release **v0.5.0**.

Bumps `pyproject.toml` and `uv.lock` from `0.4.0` → `0.5.0`.

### Since v0.4.0
- **feat: normalize task category casing** (#109, closes #107) — categories are lowercased and trimmed on write, `--category` filters match case-insensitively, and whitespace-only categories are rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)