### PR TITLE
ci: source release notes from CHANGELOG.md and publish directly

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -35,6 +35,34 @@ jobs:
             echo "publish=true" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Extract release notes from changelog
+        if: steps.check.outputs.publish == 'true'
+        run: |
+          VERSION="${{ steps.check.outputs.version }}"
+          # Release notes are the curated CHANGELOG.md section for this version,
+          # not raw commit/PR titles. Extract the block between the version's
+          # "## [x.y.z]" heading and the next "## [" heading, trimming blank
+          # lines. Runs before the PyPI publish so a missing changelog entry
+          # aborts the whole release instead of shipping empty notes.
+          awk -v ver="$VERSION" '
+            $0 ~ ("^## \\[" ver "\\]") { capture=1; next }
+            capture && /^## \[/ { exit }
+            capture { lines[n++] = $0 }
+            END {
+              start = 0
+              while (start < n && lines[start] ~ /^[[:space:]]*$/) start++
+              end = n - 1
+              while (end >= start && lines[end] ~ /^[[:space:]]*$/) end--
+              for (i = start; i <= end; i++) print lines[i]
+            }
+          ' CHANGELOG.md > release-notes.md
+          if [ ! -s release-notes.md ]; then
+            echo "::error::No CHANGELOG.md entry for v${VERSION}. Add a '## [${VERSION}]' section before releasing."
+            exit 1
+          fi
+          echo "Release notes for v${VERSION}:"
+          cat release-notes.md
+
       - uses: astral-sh/setup-uv@v8.1.0
         if: steps.check.outputs.publish == 'true'
         with:
@@ -48,7 +76,7 @@ jobs:
         if: steps.check.outputs.publish == 'true'
         uses: pypa/gh-action-pypi-publish@release/v1
 
-      - name: Tag and create draft release
+      - name: Tag and create release
         if: steps.check.outputs.publish == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -58,8 +86,11 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git tag -a "v${VERSION}" -m "Release v${VERSION}"
           git push origin "v${VERSION}"
+          # Publish directly (not a draft): the package is already live on PyPI
+          # by this step, so a draft would gate nothing. Notes are the curated
+          # CHANGELOG.md section extracted above, not raw commit/PR titles.
           gh release create "v${VERSION}" \
             --title "v${VERSION}" \
-            --generate-notes \
-            --draft \
+            --notes-file release-notes.md \
+            --latest \
             dist/*

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -87,8 +87,7 @@ jobs:
           git tag -a "v${VERSION}" -m "Release v${VERSION}"
           git push origin "v${VERSION}"
           # Publish directly (not a draft): the package is already live on PyPI
-          # by this step, so a draft would gate nothing. Notes are the curated
-          # CHANGELOG.md section extracted above, not raw commit/PR titles.
+          # by this step, so a draft would gate nothing.
           gh release create "v${VERSION}" \
             --title "v${VERSION}" \
             --notes-file release-notes.md \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,14 +62,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `done` and `undo` commands: mark a task complete with `odot done <id>`
-  (or interactively) and revert with `odot undo <id>`.
+  (or interactively) and revert with `odot undo <id>` (#84).
 - The database now auto-initializes on first use — no need to run
-  `odot init-db` before adding a task.
+  `odot init-db` before adding a task (#83).
 
 ### Fixed
 
 - Task content and category names are now HTML-escaped in generated reports,
-  preventing XSS in report output.
+  preventing XSS in report output (#81).
 
 ### Changed
 
@@ -80,44 +80,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Modernized the README: badges, cleaner layout, and updated usage examples.
+- Modernized the README: badges, cleaner layout, and updated usage examples (#65).
 
 ## [0.2.0] - 2026-03-06
 
 ### Added
 
-- Category filtering on the task list via `--category`.
-- `odot search <phrase>` to find tasks by keyword.
-- Clear commands to remove all tasks, or only completed ones.
-- JSON import/export via `odot export` and `odot import`.
-- List sorting by priority, date, category, or status via `--sort`.
-- An `updated_at` timestamp tracking when a task was last modified.
-- Markdown and HTML report generation.
+- Category filtering on the task list via `--category` (#33).
+- `odot search <phrase>` to find tasks by keyword (#34).
+- Clear commands to remove all tasks, or only completed ones (#35, #36).
+- JSON import/export via `odot export` and `odot import` (#37).
+- List sorting by priority, date, category, or status via `--sort` (#39).
+- An `updated_at` timestamp tracking when a task was last modified (#40).
+- Markdown and HTML report generation (#41).
 
 ### Fixed
 
 - Renamed the `--pending` flag to `--todo` to resolve a collision with `-p`
-  (priority).
+  (priority) (#29).
 - Replaced a leaky session generator with explicit `ctx.call_on_close`
-  cleanup.
+  cleanup (#30).
 
 ## [0.1.1] - 2026-03-01
 
 ### Added
 
 - `just lock-upgrade` now opens a pull request automatically when dependency
-  updates change the lockfile.
+  updates change the lockfile (#11, #12, #13).
 
 ### Changed
 
-- CI hardened to enforce branch protection against direct lockfile upgrades.
+- CI hardened to enforce branch protection against direct lockfile upgrades (#10).
 - Dependency updates: sqlmodel 0.0.37, ruff 0.15.4, ty 0.0.19, rich 14.3.3,
   actions/checkout v6, astral-sh/setup-uv v7.
 
 ### Fixed
 
 - Resolved a duplicate auth header that caused the bump-version workflow to
-  fail.
+  fail (#15).
 
 [Unreleased]: https://github.com/jkomalley/odot/compare/v0.5.0...HEAD
 [0.5.0]: https://github.com/jkomalley/odot/compare/v0.4.0...v0.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-07-17
+
+### Changed
+
+- Task categories are normalized to lowercase and trimmed on write, so
+  differences in casing or surrounding whitespace can no longer create
+  duplicate categories. `--category` filters are matched case-insensitively
+  against the normalized values. Existing database rows are not migrated (#109).
+
+### Fixed
+
+- Interactive selection (`odot done`, `update`, or `rm` with no id) no longer
+  crashes from an incompatible `questionary` key/search-filter combination (#108).
+- Invalid `--priority` and other input-validation failures in `add`/`update`
+  now report a clean error instead of a raw traceback, and stay within the
+  `--json` output contract (#108).
+- An empty `--category ""` is rejected instead of being silently stored (#108).
+- Markdown and HTML report headers show the raw category, so categories that
+  differ only in case no longer render as identical, indistinguishable
+  headers (#108).
+
 ## [0.4.0] - 2026-07-14
 
 ### Added
@@ -98,7 +119,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Resolved a duplicate auth header that caused the bump-version workflow to
   fail.
 
-[Unreleased]: https://github.com/jkomalley/odot/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/jkomalley/odot/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/jkomalley/odot/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/jkomalley/odot/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/jkomalley/odot/compare/v0.2.1...v0.3.0
 [0.2.1]: https://github.com/jkomalley/odot/compare/v0.2.0...v0.2.1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,8 @@ Key design decisions:
 - Commits must be atomic and follow Conventional Commits (`feat`, `fix`, `docs`, `chore`, `refactor`, `test`, `ci`, `deps`): one logical change per commit.
 - PRs that resolve an issue reference it with `Closes #N` so it closes automatically on merge.
 - PRs are squash-merged.
+- **Keep `CHANGELOG.md` release-ready.** Any user-facing change adds a bullet under `## [Unreleased]` in the same PR (internal-only refactors, CI, test, and docs changes are exempt). Entries follow the existing Keep a Changelog style — grouped under `### Added`/`### Changed`/`### Fixed`/`### Removed`, one line each, ending with the PR ref `(#N)`.
+- **Releases are automated and notes come from the changelog — never hand-written commit dumps.** The CD workflow publishes to PyPI when a version bump lands on `main`, then publishes a GitHub release whose body is that version's `CHANGELOG.md` section (extracted between its `## [x.y.z]` heading and the next; it fails the release if the section is missing). Cutting a release is a `chore: release vX.Y.Z` PR that bumps the version and renames `## [Unreleased]` to `## [X.Y.Z] - <date>` (adding a fresh empty `## [Unreleased]` and updating the compare links). See CONTRIBUTING.md → Releasing.
 
 ## Code Style
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,6 +89,9 @@ you'd rather not install `just`.
 - Keep commits atomic and use [Conventional Commits](https://www.conventionalcommits.org/)
   (`feat`, `fix`, `docs`, `chore`, `refactor`, `test`, `ci`, `deps`).
 - Include tests for any new or changed behavior.
+- Add a bullet under `## [Unreleased]` in `CHANGELOG.md` for any user-facing
+  change, so the changelog is always release-ready (internal-only refactors,
+  CI, and docs changes are exempt).
 - Reference the issue a PR resolves with `Closes #N` so it closes automatically.
 - Make sure `just check` passes cleanly before you open the PR.
 - PRs are squash-merged.
@@ -101,7 +104,20 @@ Releases are published to PyPI automatically: the release workflow fires when
 CI passes on `main` and publishes whenever `pyproject.toml`'s version isn't
 already on PyPI. So a release is just a version bump merged to `main` — once
 it lands, the workflow builds the package, publishes it to PyPI, tags the
-commit, and drafts a GitHub release.
+commit, and publishes a GitHub release whose notes are the `CHANGELOG.md`
+section for that version.
+
+Because the notes come straight from `CHANGELOG.md`, keep it current as you go
+(see the changelog bullet under [Pull requests](#pull-requests)). Cutting a
+release is then a `chore: release vX.Y.Z` PR that, in one commit:
+
+- bumps the version (below),
+- renames `## [Unreleased]` to `## [X.Y.Z] - YYYY-MM-DD` and adds a fresh empty
+  `## [Unreleased]` above it, and
+- updates the compare links at the bottom of `CHANGELOG.md`.
+
+If the bumped version has no `CHANGELOG.md` section, the release workflow fails
+rather than shipping empty notes.
 
 Choose the bump from the changes since the **last release tag**, not just your
 latest work:


### PR DESCRIPTION
## Summary

Makes `CHANGELOG.md` the single, curated source of release notes, and keeps it that way.

**Release workflow (`cd.yml`)**
- Notes now come from the version's `CHANGELOG.md` section (extracted between its `## [x.y.z]` heading and the next), published via `--notes-file` — curated, user-facing prose instead of raw commit/PR titles.
- The extraction runs **before** the PyPI publish and **fails the release if the section is missing**, so notes can't silently go stale.
- Publishes directly (`--draft` → `--latest`) — the package is already live on PyPI by that step, so a draft gated nothing.

**Changelog**
- Backfills the skipped `[0.5.0]` section (#109 + the #108 fixes) and updates compare links.
- Adds `(#N)` PR references to the pre-0.4 entries so the whole file is consistent.

**Docs (`CONTRIBUTING.md`, `CLAUDE.md`)**
- Codifies: notes come from the changelog (never commit dumps); every user-facing PR updates `## [Unreleased]`; a release PR promotes `[Unreleased]` → `[x.y.z]`. Corrects the stale "drafts a GitHub release" wording.

## Done out-of-band (not in this diff)

- All published GitHub releases (v0.1.1–v0.5.0) had their notes rewritten to match their `CHANGELOG.md` sections, so the Releases page is consistent now, not just going forward.

## Notes

- Considered a per-PR CI check requiring an `[Unreleased]` entry, but dropped it as overkill — the CD-time gate plus the documented convention are the enforcement.

## Testing

- Section extraction verified locally for every version (v0.1.1–v0.5.0) and confirmed to exit non-zero for a missing version.
- Both workflow YAMLs validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)