### PR TITLE
ci: group Dependabot dev-dependency and action updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,14 +1,22 @@
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    commit-message:
-      prefix: "deps"
   - package-ecosystem: "uv"
     directory: "/"
     schedule:
       interval: "weekly"
     commit-message:
       prefix: "deps"
+    groups:
+      dev-dependencies:
+        dependency-type: "development"
+        update-types: ["minor", "patch"]
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "deps"
+    groups:
+      actions:
+        patterns: ["*"]


### PR DESCRIPTION
Dependabot was opening one PR per package here — five are open right now from a single week. This groups dev-dependency minor/patch bumps into a single weekly PR and groups action bumps, while keeping individual PRs for runtime dependencies (pydantic, questionary, rich, sqlmodel, typer) so those stay reviewable one at a time.

Also aligns the file with the shared pattern now used across the other six repos.

The five currently-open PRs are unaffected; Dependabot applies the new grouping on the next scheduled run.

Note: `astral-sh/setup-uv` is pinned at v7 in one workflow and v8.1.0 in another — the grouped action PR should reconcile that.
🤖 Generated with [Claude Code](https://claude.com/claude-code)