### PR TITLE
ci: ignore ruff PLR0917

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,7 @@ ignore = [
     "S101",   # use of assert (needed in tests, fine in internal code)
     "PLR2004",# magic value used in comparison
     "PLR0913",# too many arguments — typer commands take many CLI params
+    "PLR0917",# too many positional arguments — same reason as PLR0913
     "CPY001", # missing copyright notice
     "FBT001", # boolean positional arg — typer flags and keyword-called APIs
     "FBT002", # boolean positional default — same as above


### PR DESCRIPTION
ruff 0.15.22 promoted `PLR0917` (too many positional arguments) to stable. With `select = ["ALL"]` this immediately fails `lint-check` on 4 sites:

- `cli.py:393` `list_tasks` (7 > 5)
- `cli.py:582` `update` (7 > 5)
- `cli.py:885` `report_cmd` (6 > 5)
- `core.py:198` `export_tasks` (6 > 5)

This is blocking the grouped dev-dependencies bump (#119), which fails on all four Python versions at the Lint step.

Ignoring it for the same reason `PLR0913` is already ignored — typer commands take many CLI params, and `export_tasks` is called by keyword in practice. The alternative, forcing keyword-only params with `*`, would churn four public signatures to satisfy a lint rule.

Verified locally against the #119 dependency set (ruff 0.15.22, ty 0.0.61, pytest 9.1.1): `just check` passes, 218 tests, 100% coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)